### PR TITLE
Sessions to be used only in controllers and blocks

### DIFF
--- a/design-documents/sessions-only-for-html.md
+++ b/design-documents/sessions-only-for-html.md
@@ -1,0 +1,20 @@
+### Magento\Framework\Session\SessionManagerInterface should be used only in controllers and blocks
+#### Why?
+Web APIs (REST (by definition), SOAP, GraphQL) do not employ sessions,
+relying on sessions in classes that are not directly linked to preparing HTML
+may cause sessions being used during Web API requests unintentionally causing
+unexpected behaviour during and negative performance impact.
+ 
+#### Current situation
+Sessions are being used in model classes.
+ 
+#### What has to be done
+Add PHPMD rule which will be triggered when a class has a constructor parameter of type
+SessionManagerInterface (and any of the implementations) and is not an instance of
+ActionInterface or AbstractBlock.
+The rule's message should explain that UserContextInterface should be used to get current
+user instead of sessions.
+ 
+Removing all existing session usages from non-controller and non-block classes would
+prove a difficult process so we just have to warn developers not to use them
+in the future with the PHPMD rule.

--- a/design-documents/sessions-only-for-html.md
+++ b/design-documents/sessions-only-for-html.md
@@ -1,20 +1,20 @@
-### Magento\Framework\Session\SessionManagerInterface should be used only in controllers and blocks
+### Magento\Framework\Session\SessionManagerInterface and Magento\Framework\Stdlib\Cookie\CookieReaderInterface should be used only in HTML related presentation level
 #### Why?
-Web APIs (REST (by definition), SOAP, GraphQL) do not employ sessions,
-relying on sessions in classes that are not directly linked to preparing HTML
+Web APIs (REST (by definition), SOAP, GraphQL) do not employ sessions and cookies,
+relying on sessions and cookies in classes that are not directly linked to preparing HTML
 may cause sessions being used during Web API requests unintentionally causing
 unexpected behaviour during and negative performance impact.
  
 #### Current situation
-Sessions are being used in model classes.
+Sessions and cookies are being used in model classes.
  
 #### What has to be done
 Add PHPMD rule which will be triggered when a class has a constructor parameter of type
-SessionManagerInterface (and any of the implementations) and is not an instance of
-ActionInterface or AbstractBlock.
+SessionManagerInterface/CookieReaderInterface (and any of the implementations) and are not a part of HTML presentation level
+(instances of ActionInterface, AbstractBlock, DataProviderInterface, Document).
 The rule's message should explain that UserContextInterface should be used to get current
-user instead of sessions.
+user instead of sessions and cookie usage should be avoided.
  
-Removing all existing session usages from non-controller and non-block classes would
-prove a difficult process so we just have to warn developers not to use them
+Removing all existing session and cookie usages from classes that are not a part of HTML presentation level would
+prove to be a difficult process so we just have to warn developers not to use them
 in the future with the PHPMD rule.

--- a/design-documents/sessions-only-for-html.md
+++ b/design-documents/sessions-only-for-html.md
@@ -11,7 +11,7 @@ Sessions and cookies are being used in model classes.
 #### What has to be done
 Add PHPMD rule which will be triggered when a class has a constructor parameter of type
 SessionManagerInterface/CookieReaderInterface (and any of the implementations) and are not a part of HTML presentation level
-(instances of ActionInterface, AbstractBlock, DataProviderInterface, Document).
+(instances of ActionInterface, AbstractBlock, DataProviderInterface, Document, controller and block plugins).
 The rule's message should explain that UserContextInterface should be used to get current
 user instead of sessions and cookie usage should be avoided.
  


### PR DESCRIPTION
It is unsafe to use sessions anywhere but controllers and blocks due to multiple web APIs in Magento