### PR TITLE
Added meetings workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,22 @@ The implementation process is out of scope in this project.
 After approval of the document, a new discussion may be raised basing on the issues occurred during implementation.
 It is also possible in case of new informational updates that discover hidden sides of the future implementation.
 If it is the case, a new PR should be opened to update existing document. The PR should include explained reasons for the proposed change.
+
+## Architectural Discussions
+
+Architectural Discussions are public meetings open to anyone and taking place on a regular basis (**bi-weekly**). Topics for the Architectural Discussions should be proposed in advance. If no topics are proposed prior to the meeting, it may be canceled.
+
+### Meeting notes and topics
+
+Meeting notes and topics are available as [meeting notes issues](https://github.com/magento/architecture/issues?q=is%3Aissue+is%3Aopen+label%3A%22meeting+notes%22).
+
+Prior to November 14th, 2018, meeting minotes are available at sidebar of the [wiki](https://github.com/magento/architecture/wiki)
+
+### How to propose a topic?
+
+To propose a topic:
+1. Find an issue for the next available date in the list of [meeting notes issues](https://github.com/magento/architecture/issues?q=is%3Aissue+is%3Aopen+label%3A%22meeting+notes%22)
+  1. Add your topic as a comment in format described in the issue
+2. If there is no such issue, please create one from the "Meeting Notes" template
+  1. Calculate the date based on the last meeting note. Don't worry if the date is incorrect, one of the  maintainers will fix it if necessary. Just make sure that it is a future date, so it's not missed
+  1. Add your topic as a comment in format described in the issue template


### PR DESCRIPTION
Changing workflow for meeting notes from the wiki (which was accessible for maintainers only) to issue-based system, where anybody can propose a topic by opening/updating an issue for specific meeting date.