### PR TITLE
Framework components as first-class citizens

### DIFF
--- a/design-documents/components.md
+++ b/design-documents/components.md
@@ -2,7 +2,7 @@
 
 1. Every framework component is a separate composer package with type `magento2-library` and name prefix `magento2/library-`
 2. Every `\Magento\Framework\App` component is a separate package.
-2. For backward compatibility in GitHub repo classes that used to live in `Magento\Framework` and `Magento\Framework\App` namespaces are moved to root folders of corresponding components, while all other classes of those components are moved into folder with the name of component.
+2. Classes that used to live in `Magento\Framework` and `Magento\Framework\App` namespaces are moved to root folders of corresponding components, while all other classes of those components are moved into folder with the name of component. Root namespace for such components is configured to be `\Magento\Framework` and `\Magento\Framework\App` to avoid renaming classes.
 
 *Before*
 ```

--- a/design-documents/components.md
+++ b/design-documents/components.md
@@ -1,0 +1,29 @@
+# Framework components
+
+1. Every component is a separate composer package
+2. Every `\Magento\Framework\App` component is a separate package.
+2. For backward compatibility in GitHub repo classes that used to live in `Magento\Framework` and `Magento\Framework\App` namespaces are moved to root folders of corresponding components, while all other classes of those components are moved into folder with the name of component.
+
+*Before*
+```
+Magento/
+  Framework/
+    App/
+      Action/
+        AbstractAction.php
+        ...
+      ActionInterface.php
+```
+*Now*
+```
+Magento/
+  Framework/
+    App/
+      Action/
+        Action/
+          AbstractAction.php
+        ActionInterface.php
+        composer.json
+```
+
+3. Every framework component can specify `/etc` directory where application configuration can be provided.

--- a/design-documents/components.md
+++ b/design-documents/components.md
@@ -1,6 +1,6 @@
 # Framework components
 
-1. Every component is a separate composer package
+1. Every framework component is a separate composer package with type `magento2-library` and name prefix `magento2/library-`
 2. Every `\Magento\Framework\App` component is a separate package.
 2. For backward compatibility in GitHub repo classes that used to live in `Magento\Framework` and `Magento\Framework\App` namespaces are moved to root folders of corresponding components, while all other classes of those components are moved into folder with the name of component.
 


### PR DESCRIPTION
## Problem

Magento framework components are parts for `magento/framework` package, and shipped with this package. There is no way for a lightweight application to only specify components that it will use.

Also framework components do not have ability to specify magento application configuration. This leads to application framework configuration to be stored in `app/etc` and modules (mostly `di.xml`). `app/etc/di.xml` is more than 1700 lines long.

## Solution

To provide the immediate solution to the 2 problems mentioned above, we need to split application framework to separate composer packages, and allow framework components to provide application configuration in `/etc` folder. This will allow to move all declarations from `app/etc/di.xml` to corresponding framework components.

## Open questions

1. Should there be a limitation of what types of configuration can be provided by framework components? Current answer - no, there should be no limitation for simplicity.

## POC
POC is implemented in https://github.com/magento-architects/magento2/tree/split-framework.

Use https://github.com/magento-architects/magento-project for easy installation of a "hello world" application.