### PR TITLE
MC-13864: Consumer always read config from memory

### DIFF
--- a/design-documents/asynchronous-operations/poison-pill.md
+++ b/design-documents/asynchronous-operations/poison-pill.md
@@ -5,7 +5,7 @@ poison pill
 
 ### Overview
 
-Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count it leads to wrong im-memory config/objects states and we need to introduce the way to reinit them.
+Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count it leads to outdated im-memory config/objects states and we need to introduce the way to reinit them.
 
 ### Design
 

--- a/design-documents/asynchronous-operations/poison-pill.md
+++ b/design-documents/asynchronous-operations/poison-pill.md
@@ -1,20 +1,36 @@
 ## Glossary
 
 poison pill
-: message in Data Storage that signals that consumer should die
+: message that added after list of events in Data Storage that signals that consumer should die.
 
 ### Overview
 
-Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count it leads to outdated im-memory config/objects states and we need to introduce the way to reinit them.
+Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count it could happens that our consumer keep outdated im-memory config/objects states. Considering that, we need to introduce the way to reinit them.
 
 ### Design
 
-Before process new message consumer should ask Data Storage if there are poison pill for him. If yes, consumer dies and next cron:run will start new instance of consumer.
+Basic implementation of how the pill will be added should be implemented inside Magento Framework. We will share the api that let each module call whenever it needed.
+
+Api Interface - *PoisonPillInterface* will be inside Magento Framework, implementation in MessageQueue module.
+
+PoisonPillInterface
+```php
+/**
+ * Put poison pill inside DB.
+ *
+ * @throws \Exception
+ * @return int
+ */
+public function put();
+```
+
+Before process new message, consumer will compare version of PoisonPill in-memory state with latest in DB. If version is different consumer dies and next cron:run will start new instance of consumer.
 
 #### Acceptance Criteria Fulfillment
 
-1. If consumer takes message to process after poison pill was placed, consumer must be reinited
+1. If consumer takes message to process after poison pill was placed, consumer must be reinited.
 
 #### Extension Points and Scenarios
 
-We will put poison pill into Data Storage based on common Magento extension points
+We will put poison pill into Data Storage based on common Magento extension points. 
+

--- a/design-documents/asynchronous-operations/poison-pill.md
+++ b/design-documents/asynchronous-operations/poison-pill.md
@@ -17,4 +17,4 @@ Before process new message consumer should ask Data Storage if there are poison 
 
 #### Extension Points and Scenarios
 
-We will put poison pill into Data Storage based on common Magento extension points like events and plugins
+We will put poison pill into Data Storage based on common Magento extension points

--- a/design-documents/asynchronous-operations/poison-pill.md
+++ b/design-documents/asynchronous-operations/poison-pill.md
@@ -1,0 +1,20 @@
+## Glossary
+
+poison pill
+: message in Data Storage that signals that consumer should die
+
+### Overview
+
+Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count we need to introduce the way to reinit them.
+
+### Design
+
+Before process new message consumer should ask Data Storage if there are poison pill for him. If yes, consumer dies and next cron:run will start new instance of consumer.
+
+#### Acceptance Criteria Fulfillment
+
+1. If consumer takes message to process after poison pill was placed, consumer must be reinited
+
+#### Extension Points and Scenarios
+
+We will put poison pill into Data Storage based on common Magento extension points like events and plugins

--- a/design-documents/asynchronous-operations/poison-pill.md
+++ b/design-documents/asynchronous-operations/poison-pill.md
@@ -5,7 +5,7 @@ poison pill
 
 ### Overview
 
-Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count we need to introduce the way to reinit them.
+Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count it leads to wrong im-memory config/objects states and we need to introduce the way to reinit them.
 
 ### Design
 


### PR DESCRIPTION
## Problem

Right now our consumer depends on config/objects in-memory state. After application was bootstrapped it initialize a lot of object that are always kept in memory after first load - config, websites, etc.., since our consumers are long-living and their live time limited only by message count it leads to wrong im-memory config/objects states and we need to introduce the way to reinit them
## Solution

Introduce poison pill - some message stored in Data Storage that signals that consumer must be reinited

## Requested Reviewers

@kandy @paliarush @vrann 
