### PR TITLE
Magento Coding Standard Versioning Strategy

### DIFF
--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -17,7 +17,7 @@ Given a version number `{major}`.`{minor}`.`{patch}`, following rules MUST be ap
 
 **PHP CodeSniffer OOB rule** - rule that goes out-of-box with PHP CodeSniffer, the part of its package, the part of specific Coding Standard (PSR2, Squiz, etc).
 
-**Magento rule** - Magento specific rule, tah part of Magento Coding Standard, located under [Magento2/Sniffs/](https://github.com/magento/magento-coding-standard/tree/develop/Magento2/Sniffs) directory.
+**Magento rule** - Magento specific rule, the part of Magento Coding Standard, located under [Magento2/Sniffs/](https://github.com/magento/magento-coding-standard/tree/develop/Magento2/Sniffs) directory.
 
 ### Versioning use cases
 
@@ -25,15 +25,17 @@ Following use cases are representing code change examples relatively to the vers
 
 ### `{patch}` Release
 - Bug fix to existing rule that prevents false-positive findings.
-- Removing PHP CodeSniffer OOB rule from Magento Coding Standard `ruleset.xml` file.
-- Removing Magento rule from MagentoCoding Standard (sniff code + `ruleset.xml`).
-- Adding unit tests to existing rules.
+- Implementing unit tests for existing rules.
+- Adding new `exclude-pattern` or `include-pattern` to the rule.
 
 ### `{minor}` Release
+- Removing PHP CodeSniffer OOB rule from Magento Coding Standard `ruleset.xml` file.
+
+### `{major}` Release
+- Removing Magento rule from Magento Coding Standard (sniff code + `ruleset.xml`).
 - Adding new OOB rule to Magento Coding Standard `ruleset.xml` file.
 - Implementing new Magento rule and adding it to `ruleset.xml` file.
 - Changing the behaviour of existing Magento rule (extending functionality).
-
-### `{major}` Release
+- Changing the `severity` and the `type` of the rule.
 - Changing platform requirements.
-- Namespace changes.
+- Changing namespace.

--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -12,12 +12,12 @@ General overview scheme:
 
 Single number sequence-based version identifier will be incremented every release.
 
-Once new release happens it automatically means that all users <sup>core developers, community contributors, system integrators and extension developers</sup> need to follow the latest version.
+Once new release happens it automatically means that all users core developers, community contributors, system integrators and extension developers need to follow the latest version.
 
 **Only the latest version** will be supported.
 
 ## Dependency
-Since we want all users <sup>core developers, community contributors, system integrators and extension developers</sup> to follow the latest version of Coding Standard, the dependency should be `"*"`.
+Since we want all users core developers, community contributors, system integrators and extension developers to follow the latest version of Coding Standard, the dependency should be `"*"`.
 ```
     "require-dev": {
         ...

--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -26,17 +26,23 @@ Following use cases are representing code change examples relatively to the vers
 ### `{patch}` Release
 - Bug fix to existing rule that prevents false-positive findings.
 - Implementing unit tests for existing rules.
-- Adding new `exclude-pattern` or `include-pattern` to the rule.
 
 ### `{minor}` Release
 - Removing PHP CodeSniffer OOB rule from Magento Coding Standard `ruleset.xml` file.
+- Removing Magento rule from Magento Coding Standard (sniff code + `ruleset.xml`).
+- Adding new `exclude-pattern` to the rule.
+- Decreasing the `severity`.
+- Changing `type` from `error` to `warning`.
+
+In context of Coding Standard backward incompatible change occurs when rules became stricter and produce more findings.
 
 ### `{major}` Release
-- Removing Magento rule from Magento Coding Standard (sniff code + `ruleset.xml`).
 - Adding new OOB rule to Magento Coding Standard `ruleset.xml` file.
 - Implementing new Magento rule and adding it to `ruleset.xml` file.
 - Changing the behaviour of existing Magento rule (extending functionality).
-- Changing the `severity` and the `type` of the rule.
+- Adding new `include-pattern` to the rule.
+- Increasing the `severity`.
+- Changing `type` from `warning` to `error`.
 - Changing platform requirements.
 - Changing namespace.
 

--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -1,0 +1,39 @@
+# Magento Coding Standard Versioning
+
+The purpose of this document is the defining versioning strategy for [Magento Coding Standard](https://github.com/magento/magento-coding-standard).
+
+## Summary
+
+Version number should be increased with taking [Semantic Versioning](https://semver.org/) into account.
+Given a version number `{major}`.`{minor}`.`{patch}`, following rules MUST be applied:
+
+- `{patch}` version MUST be incremented when backward compatible changes (bug fixes) were made.
+
+- `{minor}` version MUST be incremented when backward compatible changes (new features) were added.
+
+- `{major}` version MUST be incremented when backward incompatible changes were made.
+
+### Terminology
+
+**PHP CodeSniffer OOB rule** - rule that goes out-of-box with PHP CodeSniffer, the part of its package, the part of specific Coding Standard (PSR2, Squiz, etc).
+
+**Magento rule** - Magento specific rule, tah part of Magento Coding Standard, located under [Magento2/Sniffs/](https://github.com/magento/magento-coding-standard/tree/develop/Magento2/Sniffs) directory.
+
+### Versioning use cases
+
+Following use cases are representing code change examples relatively to the version part that needs to be changed.
+
+### `{patch}` Release
+- Bug fix to existing rule that prevents false-positive findings.
+- Removing PHP CodeSniffer OOB rule from Magento Coding Standard `ruleset.xml` file.
+- Removing Magento rule from MagentoCoding Standard (sniff code + `ruleset.xml`).
+- Adding unit tests to existing rules.
+
+### `{minor}` Release
+- Adding new OOB rule to Magento Coding Standard `ruleset.xml` file.
+- Implementing new Magento rule and adding it to `ruleset.xml` file.
+- Changing the behaviour of existing Magento rule (extending functionality).
+
+### `{major}` Release
+- Changing platform requirements.
+- Namespace changes.

--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -12,12 +12,12 @@ General overview scheme:
 
 Single number sequence-based version identifier will be incremented every release.
 
-Once new release happens it automatically means that all users core developers, community contributors, system integrators and extension developers need to follow the latest version.
+Once new release happens it automatically means that all users (core developers, community contributors, system integrators and extension developers) need to follow the latest version.
 
 **Only the latest version** will be supported.
 
 ## Dependency
-Since we want all users core developers, community contributors, system integrators and extension developers to follow the latest version of Coding Standard, the dependency should be `"*"`.
+Since we want all users (core developers, community contributors, system integrators and extension developers) to follow the latest version of Coding Standard, the dependency should be `"*"`.
 ```
     "require-dev": {
         ...

--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -1,67 +1,36 @@
 # Magento Coding Standard Versioning
-
 The purpose of this document is the defining versioning strategy for [Magento Coding Standard](https://github.com/magento/magento-coding-standard).
 
-## Summary
-
-Version number should be increased with taking [Semantic Versioning](https://semver.org/) into account.
-Given a version number `{major}`.`{minor}`.`{patch}`, following rules MUST be applied:
-
-- `{patch}` version MUST be incremented when backward compatible changes (bug fixes) were made.
-
-- `{minor}` version MUST be incremented when backward compatible changes (new features) were added.
-
-- `{major}` version MUST be incremented when backward incompatible changes were made.
-
-### Terminology
-
-**PHP CodeSniffer OOB rule** - rule that goes out-of-box with PHP CodeSniffer, the part of its package, the part of specific Coding Standard (PSR2, Squiz, etc).
-
-**Magento rule** - Magento specific rule, the part of Magento Coding Standard, located under [Magento2/Sniffs/](https://github.com/magento/magento-coding-standard/tree/develop/Magento2/Sniffs) directory.
-
-### Versioning use cases
-
-Following use cases are representing code change examples relatively to the version part that needs to be changed.
-
-### `{patch}` Release
-- Bug fix to existing rule that prevents false-positive findings.
-- Implementing unit tests for existing rules.
-
-### `{minor}` Release
-- Removing PHP CodeSniffer OOB rule from Magento Coding Standard `ruleset.xml` file.
-- Removing Magento rule from Magento Coding Standard (sniff code + `ruleset.xml`).
-- Adding new `exclude-pattern` to the rule.
-- Decreasing the `severity`.
-- Changing `type` from `error` to `warning`.
-
-In context of Coding Standard backward incompatible change occurs when rules became stricter and produce more findings.
-
-### `{major}` Release
-- Adding new OOB rule to Magento Coding Standard `ruleset.xml` file.
-- Implementing new Magento rule and adding it to `ruleset.xml` file.
-- Changing the behaviour of existing Magento rule (extending functionality).
-- Adding new `include-pattern` to the rule.
-- Increasing the `severity`.
-- Changing `type` from `warning` to `error`.
-- Changing platform requirements.
-- Changing namespace.
-
 ## Release Line
-Only one release line will be supported based on incremental approach depending on introduced changes.
+One release line will be supported based on incremental approach despite introduced changes (new rules, bug fixes, etc).
 General overview scheme:
 
 ```
-1.0.0
-  |
-1.0.1
-  |
-1.0.2
-  |
-  |__1.1.0
-       |
-       |__2.0.0
-            |
-            |__2.0.1
+3 - 4 - 5 - ... - 42 - ... - N
+
 ```
 
-No `{patch}` and `{minor}` releases will be made to the previous `{major}` (1.0.0) version if the new `{major}` (2.0.0) version already exists.
+Single number sequence-based version identifier will be incremented every release.
+
+Once new release happens it automatically means that all users <sup>core developers, community contributors, system integrators and extension developers</sup> need to follow the latest version.
+
+**Only the latest version** will be supported.
+
+## Dependency
+Since we want all users <sup>core developers, community contributors, system integrators and extension developers</sup> to follow the latest version of Coding Standard, the dependency should be `"*"`.
+```
+    "require-dev": {
+        ...
+        "magento/magento-coding-standard": "*",
+        ...
+    }
+```
+
+## Side Effects
+- No `patch` or `minor` dependency will be possible, so any change may lead to build (code check) failure.
+- If released Magento package will contain `"*"` dependency any update may lead to build (code check) failure.
+
+## Marketplace Notifications
+- Developers on Marketplace will be notified prior EQP will update the version for PHPCodeSniffer check.
+- Developers on Marketplace will see in the report what version was used during the check.
+- Extension will be rejected in case it does not follow the latest Coding Standard version.

--- a/design-documents/testing/static/coding-standard-versioning.md
+++ b/design-documents/testing/static/coding-standard-versioning.md
@@ -39,3 +39,23 @@ Following use cases are representing code change examples relatively to the vers
 - Changing the `severity` and the `type` of the rule.
 - Changing platform requirements.
 - Changing namespace.
+
+## Release Line
+Only one release line will be supported based on incremental approach depending on introduced changes.
+General overview scheme:
+
+```
+1.0.0
+  |
+1.0.1
+  |
+1.0.2
+  |
+  |__1.1.0
+       |
+       |__2.0.0
+            |
+            |__2.0.1
+```
+
+No `{patch}` and `{minor}` releases will be made to the previous `{major}` (1.0.0) version if the new `{major}` (2.0.0) version already exists.


### PR DESCRIPTION
## Problem
The is no document that describes [Magento Coding Standard](https://github.com/magento/magento-coding-standard) versioning.

## Solution
The proposal describes rules that need to be followed when making new [Magento Coding Standard](https://github.com/magento/magento-coding-standard) release.

## Requested Reviewers
@buskamuza 
@paliarush 
@melnikovi 
