### PR TITLE
Adding notes about gaps in SVC coverage to the improvements proposal

### DIFF
--- a/design-documents/testing/svc/improvements.md
+++ b/design-documents/testing/svc/improvements.md
@@ -40,28 +40,32 @@ Suggested approach is to compare actual configuration of the RabbitMQ after Mage
 1. The tool should ignore the order of the fields during comparison since the order can change when module installation order changes.
 1. PHP errors are ignored, but must cause build failure.
 
-# Incomplete analysis for BIC-relevant PHP code changes
+# Missing analysis for BIC-relevant PHP code changes
 
-### Type declarations
+The following categories of code changes impact backward compatibility but are missing from the analysis performed by the existing SVC tool and must be added to the ruleset.
 
-The current SVC code handles changes in type declarations (adding/removing/changing) for API method parameters and return types only if the type declarations are done in-line; `@param` and `@returns` annotations are widely used across the codebase in place of in-line type declarations and must checked for BIC.
-- [MC-16327](https://jira.corp.magento.com/browse/MC-16327) has been created to address this.
+### Type declaration annotations
+
+1. The current SVC code handles changes in type declarations (adding/removing/changing) for API method parameters and return types only if the type declarations are done in-line, but `@param` and `@returns` annotations are widely used across the codebase in place of in-line type declarations and must checked for BIC.
+1. API class properties must be checked for typing additions, removals and changes using the same change level rules as method parameters.  In-line property typing will not be supported [until PHP 7.4](https://wiki.php.net/rfc/typed_properties_v2), but we use `@var` annotations in our codebase to declare property types so they must be checked along with the `@param` and `@return` annotations.
+
+[MC-16327](https://jira.corp.magento.com/browse/MC-16327) has been created to address these issues.
 
 ### Traits
 
-Traits are used occasionally in our API (example: [Magento\Payment\Helper\Formatter](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Payment/Helper/Formatter.php)) and must be analyzed by the SVC tool the same as abstract classes.
+Traits are used occasionally in our API (example: [Magento\Payment\Helper\Formatter](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Payment/Helper/Formatter.php)) and must be analyzed by the SVC tool.  Traits must be treated the same as abstract classes for analysis except private members must have the same change level as protected members; private members of traits are accessible by extending classes and thus have BIC considerations.
 
 ### Visibility changes
 
-Changes in visibility are currently ignored; a public method moving to protected or even private does not register in the tool.  Visibility changes across all class members must be considered for BIC.
-- Suggestion: Visibility changes to be more restrictive should have the same change level as removals, changes to be more visible should have the same change level as additions.
+Visibility changes across all class members must be considered for BIC; currently, a public method moving to protected or even private does not register in the tool.  More-restrictive visibility adjustments must be treated as removals (MAJOR), less-restrictive adjustments must be treated as additions (MINOR).
 
 ### Class inheritance
 
-1. Overriding a parent method must be treated as a changed method (PATCH), currently it is treated as an added method (MINOR) even though the method already existed on the class.  Note: moving a method to a parent class is already handled as move a move operation instead of a removal and does not need to be changed.
-1. Changing the parents of a class (such as making an API class extend a different abstract class, implementing a different interface) must be considered for BIC, as the class can have different methods or other members or it could become incompatible with method parameters that expect an object of the previous parent's type.  Class parentage is currently ignored.
-1. API classes must be checked for changes to parent classes or traits they extend even if those parents aren't also marked as API, as a parent's methods and other members affect BIC for all classes that extend them. Class parentage is currently ignored.
-1. Adding a parent (implemented interface or extended class or trait) to a previously parent-less API class must be considered for BIC, as it adds methods and other members to the class and creates type compatibility constraints that must be considered for future changes.
+1. Overriding a parent method in a child API class must be treated as a changed method (PATCH), currently it is treated as an added method (MINOR) even though the method already existed on the class.  Note: moving a method to a parent class is already handled as move a move operation instead of a removal and does not need to be changed.
+1. Changing the parents of an API class (such as making the class extend a different abstract class or implement a different interface) must be a MAJOR-level change, as the class can have different methods and other members or it could become incompatible with method parameters that expect an object of the previous parent's type.
+1. Adding a parent (implemented interface or extended class or trait) to a previously parent-less API class must be considered for BIC, as it adds methods and other members to the class and creates type compatibility constraints that must be considered for future changes.  This should be a MINOR-level change.
+1. Removing a parent (implemented interface or extended class or trait) from an API class must be considered for BIC, as it removes methods and other members from the class and can cause type compatibility issues with code expecting the class to belong to the removed parent.  This should be treated the same as method removal and changes in return types (MAJOR-level).
+1. API classes must be checked for changes to parent classes or traits they extend even if those parents aren't also marked as API, as a parent's methods and other members affect BIC for all classes that extend them.
 
 # Other backward incompatible changes
 
@@ -79,7 +83,6 @@ The rest of the BiC changes listed in the [document](https://devdocs.magento.com
 
 ### SVC tool
 1. SVC must ignore removal of private constants like in [this PR](https://github.com/magento/magento2ce/pull/3875)
-1. Override of the method defined in parent must be treated by SVC as Patch change
 1. Adding optional parameter to the constructor must be detected as Patch change for all classes except for the explicitly defined list of classes used for extension. Examples of such classes include legacy layer supertypes like `AbstractExtensibleModel`
 
 ### DB comparison tool


### PR DESCRIPTION
## Problem

The SVC tool has gaps in analysis for BIC-relevant changes including annotation-based type declarations, traits, visibility, and inheritance.

## Proposed solutions

 - **Type annotations:** Treat `@param`, `@var`, and `@return` type annotations the same as in-line declarations.
 - **Traits:** Add trait analysis using `PHPSemVerChecker\Analyzer\TraitAnalyzer` as a template, treating traits the same as abstract classes.
 - **Visibility:** Treat more-permissive visibility changes at the same change level as additions, less-permissive changes at the same level as removals.
 - **Inheritance-related changes:**
   1. Treat overriding a parent method as a changed method (PATCH) instead of an added method (MINOR).
   1. Treat changing which parent interfaces, classes, or traits are implemented or extended by a class as MAJOR-level.
   1. Treat adding a parent (implemented interface or extended class or trait) to an API class as MINOR-level and removing a parent as MAJOR-level for type compatibility even if the overall class members didn't change.
   1. Analyze parent classes and traits extended by API classes for BIC changes even if those parents aren't also marked as API.

## Requested Reviewers

 - @buskamuza @paliarush - Versioning and backwards compatibility
