### PR TITLE
Voting on Proposals

### DIFF
--- a/decision-making/voting-on-proposals.md
+++ b/decision-making/voting-on-proposals.md
@@ -1,26 +1,26 @@
 # Voting on Proposals
-Architecture team leads proposal handling and is responsible for procedure compliance.
+The Architecture team handles the proposal workflow and is responsible for procedural compliance.
 
-### Proposal submission
-- Proposal is submitted by opening pull request to this repository.
-- Initiator must present the idea on the architecture meeting.
-- The announcement should include a problem the proposal is trying to resolve as well as solution(s).
+## Proposal submission
+- A proposal is submitted by opening a pull request to this repository.
+- The initiator must present the idea in an architecture meeting.
+- The announcement should include the problem the proposal is trying to resolve as well as any proposed solution(s).
 
-### Discussion and Voting
-- If there are controversial opinions in relation to the proposed idea architecture team may consider starting the voting.
-- The voting is considered open when `voting` label is added to the pull request.
+## Discussion and Voting
+- If there are controversial opinions in relation to the proposed idea, the architecture team may consider starting the voting.
+- The voting is considered open when the `voting` label is added to the pull request.
 - The voting can be represented as a single/multiple answer survey.
-- A valid voting period must be announced when the voting is started, must be greater that 1 week and must not be changed during the voting.
+- A valid voting period: 1) must be announced when the voting is started, 2) must be greater that 1 week and 3) must not be changed during the voting.
 - The Discussion may continue in the pull request thread.
 - Voters cannot change their vote during the voting period.
-- Intermediate results should be hidden until the voting period ends.
+- Results should be hidden until the voting period ends.
 
-### Results
+## Results
 - Voting results should be added to the corresponding pull request.
 - Participants should be mentioned by name.
 - When a majority vote exists for a proposal, it does not guarantee that the proposal will be adopted or implemented.
 
-# Eligible voters
+## Eligible voters
 All active GitHub users are treated as eligible voters.
 
 ## To Do

--- a/decision-making/voting-on-proposals.md
+++ b/decision-making/voting-on-proposals.md
@@ -1,0 +1,30 @@
+# Decision-making
+
+### Proposal submission
+Proposal is submitted by opening pull request to this repository.
+Initiator must present the idea on the architecture meeting.
+The announcement should include problem description the proposal is trying to resolve as well as solution(s).
+
+### Discussion
+There must be minimum 2 weeks of discussion in the pull request thread.
+After that initiator may decide when to start the vote.
+
+### Voting
+All eligible voters must get notification about the voting start.
+A valid voting period must be announced when voting is started, must be greater that 2 weeks and must not be changed during the vote.
+
+### Approval
+The number of `approve` votes must be greater than or equal to the number of `reject` votes multiplied by two in order to merge pull request.
+In case of multi-choice voting (implementation details) the decision may be taken by simple plurality. This means that the voting option with the most votes wins. If there are multiple options with the most number of votes, the initiator can choose one of them.
+Once pull request is merged the proposal is accepted.
+
+# Eligible voters
+The group of eligible voters should be established. The group should represent the Magento community and include internal developers and architects (40%), Magento maintainers (30%), extension developers and partner contributors (30%).
+
+## To Do
+- GitHub application for survey.
+- GitHub user group with eligible voters.
+
+_Inspired by:_
+- [Request for Comments: Voting on PHP features](https://wiki.php.net/rfc/voting)
+- [PHP-FIG Public Survey](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide-meta.md#44-public-survey)

--- a/decision-making/voting-on-proposals.md
+++ b/decision-making/voting-on-proposals.md
@@ -1,29 +1,30 @@
-# Decision-making
+# Voting on Proposals
+Architecture team leads proposal handling and is responsible for procedure compliance.
 
 ### Proposal submission
-Proposal is submitted by opening pull request to this repository.
-Initiator must present the idea on the architecture meeting.
-The announcement should include problem description the proposal is trying to resolve as well as solution(s).
+- Proposal is submitted by opening pull request to this repository.
+- Initiator must present the idea on the architecture meeting.
+- The announcement should include a problem the proposal is trying to resolve as well as solution(s).
 
-### Discussion
-There must be minimum 2 weeks of discussion in the pull request thread.
-After that initiator may decide when to start the vote.
+### Discussion and Voting
+- If there are controversial opinions in relation to the proposed idea architecture team may consider starting the voting.
+- The voting is considered open when `voting` label is added to the pull request.
+- The voting can be represented as a single/multiple answer survey.
+- A valid voting period must be announced when the voting is started, must be greater that 1 week and must not be changed during the voting.
+- The Discussion may continue in the pull request thread.
+- Voters cannot change their vote during the voting period.
+- Intermediate results should be hidden until the voting period ends.
 
-### Voting
-All eligible voters must get notification about the voting start.
-A valid voting period must be announced when voting is started, must be greater that 2 weeks and must not be changed during the vote.
-
-### Approval
-The number of `approve` votes must be greater than or equal to the number of `reject` votes multiplied by two in order to merge pull request.
-In case of multi-choice voting (implementation details) the decision may be taken by simple plurality. This means that the voting option with the most votes wins. If there are multiple options with the most number of votes, the initiator can choose one of them.
-Once pull request is merged the proposal is accepted.
+### Results
+- Voting results should be added to the corresponding pull request.
+- Participants should be mentioned by name.
+- When a majority vote exists for a proposal, it does not guarantee that the proposal will be adopted or implemented.
 
 # Eligible voters
-The group of eligible voters should be established. The group should represent the Magento community and include internal developers and architects (40%), Magento maintainers (30%), extension developers and partner contributors (30%).
+All active GitHub users are treated as eligible voters.
 
 ## To Do
-- GitHub application for survey.
-- GitHub user group with eligible voters.
+- Use [Community Portal](https://opensource.magento.com/) for surveys and vote tracking.
 
 _Inspired by:_
 - [Request for Comments: Voting on PHP features](https://wiki.php.net/rfc/voting)

--- a/decision-making/voting-on-proposals.md
+++ b/decision-making/voting-on-proposals.md
@@ -12,7 +12,7 @@ The Architecture team handles the proposal workflow and is responsible for proce
 - The voting can be represented as a single/multiple answer survey.
 - A valid voting period: 1) must be announced when the voting is started, 2) must be greater that 1 week and 3) must not be changed during the voting.
 - The Discussion may continue in the pull request thread.
-- Voters cannot change their vote during the voting period.
+- Voters can change their vote during the voting period.
 - Results should be hidden until the voting period ends.
 
 ## Results


### PR DESCRIPTION
## Problem

Right now there is no mechanism to handle public proposals and reflect the actual community attendance. There is a way to submit proposals and participate in the discussion, but there is no way to participate in decision-making.
Many proposals produce conflict discussion and there is no established way to resolve it. Initiators are trying to resolve this with Twitter survey, but it doesn’t show who voted and allows any Twitter user to vote.

## Solution

This document represents the procedure to submit new proposals to the Magento community, vote and make decisions.

## Requested Reviewers

@maghamed 
@antonkril 
@okorshenko 
