### PR TITLE
Single mutation for adding products to cart + wishlist

### DIFF
--- a/design-documents/graph-ql/coverage/AddProductsToCart.graphqls
+++ b/design-documents/graph-ql/coverage/AddProductsToCart.graphqls
@@ -1,0 +1,25 @@
+type Mutation {
+    addProductsToCart(input: AddProductsToCartInput): AddProductsToCartOutput
+}
+
+input AddProductsToCartInput {
+    cart_id: String!,
+    cart_items: [CartItemInput!]!
+}
+
+input CartItemInput {
+    sku: String! # already in use
+    quantity: Float # already in use
+    parent_sku: String, # will not be used in deprecated methods
+    selected_options: [String!] # will not be used in deprecated methods
+    entered_options: [EnteredOptionInput!] # will not be used in deprecated methods
+}
+
+input EnteredOptionInput {
+    id: String!
+    value: String!
+}
+
+type AddProductsToCartOutput {
+    cart: Cart!
+}

--- a/design-documents/graph-ql/coverage/AddProductsToWishlist.graphqls
+++ b/design-documents/graph-ql/coverage/AddProductsToWishlist.graphqls
@@ -1,0 +1,15 @@
+type Mutation {
+    addProductsToWishlist(input: AddProductsToWishlistInput): WishlistOutput
+}
+
+input AddProductsToWishlistInput {
+    wishlist_items: [WishlistItemInput!]!
+}
+
+input WishlistItemInput {
+    sku: String
+    quantity: Float
+    parent_sku: String,
+    selected_options: [String!]
+    entered_options: [EnteredOptionInput!]
+}

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -21,12 +21,12 @@ In order to simplify the flow of adding different type of products to wishlist a
     "sku": "Cup",
     "qty": 1,
     "selected_options" : [
-      base64_encode('configurable/24/42')
+      "Y29uZmlndXJhYmxlLzI0LzQy"
     ],
     "entered_options": [
       {
-        id: 31,
-        value: base64_encode('Vasia's awesome cup')
+        id: "Y3VzdG9tLW9wdGlvbi8zMQ==",
+        value: "VmFzaWEncyBhd2Vzb21lIGN1cA=="
       }
     ]
   }
@@ -35,7 +35,7 @@ In order to simplify the flow of adding different type of products to wishlist a
 
 In this example we want to add _personalized blue cup to cart_ to cart.
 
- - `selected_options` - predefined and selected by customer options. `base64` encoding will help to use UUID in future. In this example values will be following:
+ - `selected_options` - `base64_encode('configurable/24/42')` predefined and selected by customer options. `base64` encoding will help to use UUID in future. In this example values will be following:
 
     | Name  | Value | Buyer Selection |
     | ------------- | ------------- | ------------- |
@@ -43,28 +43,38 @@ In this example we want to add _personalized blue cup to cart_ to cart.
     | option-id  | 24 | color |
     | option-value-id  | 42  | blue |
 - `option-type` - predefined list of option types, e.g. downloadable, configurable, bundle, customizable.
-- `entered_options` - entered by customer options.
+- `entered_options` - entered and encoded by customer options.
+```
+"entered_options": [
+      {
+        id: base64_encode("custom-option/31"),
+        value: base64_encode("Vasia's awesome cup")
+      }
+    ]
+```
 
 This example is suitable for virtual product and gift card as well.
 
 #### Add virtual product to cart
 In this example we want to add _personalized membership with expiration date_ to cart.
-    | Name  | Value | Buyer Selection |
-    | ------------- | ------------- | ------------- |
-    | option-type  | configurable   |
-    | option-id  | 105 | date |
-    | option-value-id  | 156  | 12/31/2020 |
+
+| Name  | Value | Buyer Selection |
+| ------------- | ------------- | ------------- |
+| option-type  | configurable   |
+| option-id  | 105 | date |
+| option-value-id  | 156  | 12/31/2020 |
+
 ```
 [
   {
     "sku": "Membership",
     "selected_options" : [
-      base64_encode('configurable/105/156')
+      "Y29uZmlndXJhYmxlLzEwNS8xNTY="
     ],
     "entered_options": [
       {
-        id: 31,
-        value: base64_encode('Vasia's awesome cup')
+        id: "Y3VzdG9tLW9wdGlvbi8zMQ==",
+        value: "VmFzaWEncyBhd2Vzb21lIGN1cA=="
       }
     ]
   }
@@ -80,29 +90,27 @@ In this example we want to add _100$ gift card_ to cart.
     "sku": "Gift Card",
     "entered_options": [
       {
-        id: 55,
-        value: base64_encode('100')
+        id: "Z2lmdC1jYXJkLWFtb3VudA==",
+        value: "MTAw"
       }
     ]
   }
 ]
 ```
 
-
 #### Add downloadable product to cart
-Here `selected_options` contain `link-id`.
 ```
 [
   {
     "sku": "Video tutorial",
     "qty": 1,
     "selected_options" : [
-      base64_encode('downloadable/13')
+      "ZG93bmxvYWRhYmxlLzEz"
     ]
   }
 ]
 ```
-
+Where `selected_options` contain link id: `base64_encode('downloadable/13')` -> `ZG93bmxvYWRhYmxlLzEz`.
 #### Add bundle product to cart
 In this example we want to add _dinnerware kit, that contains cup and saucer_ to cart.
 ```
@@ -128,7 +136,7 @@ In this example we want to add _dinnerware kit, that contains cup and saucer_ to
     "qty": 1,
     "parent_sku": "Kit",
     "selected_options" : [
-      base64_encode(configurable/42/24)
+      "Y29uZmlndXJhYmxlLzQyLzI0"
     ],
   },
   {
@@ -136,7 +144,7 @@ In this example we want to add _dinnerware kit, that contains cup and saucer_ to
     "qty": 1,
     "parent_sku": "Kit",
     "selected_options" : [
-      base64_encode(configurable/42/24)
+      "Y29uZmlndXJhYmxlLzQyLzI0"
     ],
   },
 ]
@@ -150,7 +158,7 @@ In this example we want to add _glass blue cup to cart_.
     "sku": "Glass Cup",
     "qty": 1,
     "selected_options" : [
-      base64_encode(configurable/42/24)
+      "Y29uZmlndXJhYmxlLzQyLzI0"
     ]
   }
 ]
@@ -164,7 +172,7 @@ Following approach will work with the partial option selection, for example for 
     "qty": 1,
     "parent_sku": "Glass Cup",
     "selected_options" : [
-      base64_encode(configurable/42/24)
+      "Y29uZmlndXJhYmxlLzQyLzI0"
     ],
   }
 ]
@@ -196,7 +204,7 @@ Wishlist functionality will preserve the same behaviour with the only difference
     "entered_options": [
       {
         id: 31,
-        value: base64_encode('Vasia's awesome cup')
+        value: "VmFzaWEncyBhd2Vzb21lIGN1cA=="
       }
     ]
   }

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -39,7 +39,7 @@ In this example we want to add _personalized blue cup to cart_ to cart.
 :warning: The encoded value will be returned from server and should be used by client as is. In order to achieve this:
 
 ``` graphql
-interface CustomizableOptionInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\CustomizableOptionTypeResolver") @doc(description: "The CustomizableOptionInterface contains basic information about a customizable option. It can be implemented by several types of configurable options.") {
+interface CustomizableOptionInterface {
     ...
     id: ID @doc(description: "Option ID.")
 }

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -73,11 +73,11 @@ In this example we want to add _personalized membership with expiration date_ to
 
 #### Add giftcard to cart
 In this example we want to add _100$ gift card_ to cart.
-`entered_options` will contain encoded info of gift car amount.
+`entered_options` will contain encoded info about gift card amount.
 ```
 [
   {
-    "sku": "Membership",
+    "sku": "Gift Card",
     "entered_options": [
       {
         id: 55,

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -43,14 +43,14 @@ In this example we want to add _personalized blue cup to cart_ to cart.
     | option-id  | 24 | color |
     | option-value-id  | 42  | blue |
 - `option-type` - predefined list of option types, e.g. downloadable, configurable, bundle, customizable.
-- `entered_options` - entered and encoded by customer options.
+- `entered_options` - entered by customer and encoded options.
 ```
 "entered_options": [
-      {
-        id: base64_encode("custom-option/31"),
-        value: base64_encode("Vasia's awesome cup")
-      }
-    ]
+  {
+    id: base64_encode("custom-option/31"),
+    value: base64_encode("Vasia's awesome cup")
+  }
+]
 ```
 
 This example is suitable for virtual product and gift card as well.

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -10,8 +10,7 @@ In order to simplify the flow of adding different type of products to wishlist a
 - Bundle dynamic, grouped and configurable product are just templates which help merchant to select a set of simple products.
 - Product may have selected options and entered options (buyer input).
 - Options are sets of predefined values that a buyer can add to cart/wishlist in addition to a product.
-- Some of the options can be required by its nature but not by API signature.
-- The differences in payloads between wishlist and cart is that all fields in wishlist are optional.
+- The difference between wishlist and cart payloads is that all fields in wishlist are optional.
 
 ### Examples
 
@@ -34,22 +33,64 @@ In order to simplify the flow of adding different type of products to wishlist a
 ]
 ```
 
-In this example we want to add _personalized blue cup to cart_.
+In this example we want to add _personalized blue cup to cart_ to cart.
 
  - `selected_options` - predefined and selected by customer options. `base64` encoding will help to use UUID in future. In this example values will be following:
 
-    | Name  | Value | Real Data |
+    | Name  | Value | Buyer Selection |
     | ------------- | ------------- | ------------- |
     | option-type  | configurable   |
     | option-id  | 24 | color |
     | option-value-id  | 42  | blue |
-- `option-type` - predefined list of option types, e.g. downloadable link, configurable option, bundle option, customizable option.
+- `option-type` - predefined list of option types, e.g. downloadable, configurable, bundle, customizable.
 - `entered_options` - entered by customer options.
 
 This example is suitable for virtual product and gift card as well.
 
+#### Add virtual product to cart
+In this example we want to add _personalized membership with expiration date_ to cart.
+    | Name  | Value | Buyer Selection |
+    | ------------- | ------------- | ------------- |
+    | option-type  | configurable   |
+    | option-id  | 105 | date |
+    | option-value-id  | 156  | 12/31/2020 |
+```
+[
+  {
+    "sku": "Membership",
+    "selected_options" : [
+      base64_encode('configurable/105/156')
+    ],
+    "entered_options": [
+      {
+        id: 31,
+        value: base64_encode('Vasia's awesome cup')
+      }
+    ]
+  }
+]
+```
+
+#### Add giftcard to cart
+In this example we want to add _100$ gift card_ to cart.
+`entered_options` will contain encoded info of gift car amount.
+```
+[
+  {
+    "sku": "Membership",
+    "entered_options": [
+      {
+        id: 55,
+        value: base64_encode('100')
+      }
+    ]
+  }
+]
+```
+
+
 #### Add downloadable product to cart
-Here `selected_options` contain `<option-type>/<link-id>`.
+Here `selected_options` contain `link-id`.
 ```
 [
   {
@@ -63,17 +104,18 @@ Here `selected_options` contain `<option-type>/<link-id>`.
 ```
 
 #### Add bundle product to cart
+In this example we want to add _dinnerware kit, that contains cup and saucer_ to cart.
 ```
 [
   {
     "sku": "Cup",
     "qty": 1,
-    "parent_sku": "Kit",
+    "parent_sku": "Dinnerware Kit",
   },
   {
-    "sku": "Plate",
+    "sku": "Saucer",
     "qty": 1,
-    "parent_sku":  "Kit",
+    "parent_sku":  "Dinnerware Kit",
   }
 ]
 ```
@@ -99,7 +141,6 @@ Here `selected_options` contain `<option-type>/<link-id>`.
   },
 ]
 ```
-
 
 #### Add configurable product to cart
 In this example we want to add _glass blue cup to cart_.
@@ -134,7 +175,7 @@ Following approach will work with the partial option selection, for example for 
 [
   {
     "sku": "Cup Small",
-    "qty": 1.
+    "qty": 1
   },
   {
     "sku": "Cup Big",
@@ -143,6 +184,7 @@ Following approach will work with the partial option selection, for example for 
 ]
 ```
 :warning: Grouped product should be added to cart without parent, but to wish list - with parent.
+
 Wishlist functionality will preserve the same behaviour with the only difference that all fields are optional.
 
 #### Add product to wishlist

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -1,0 +1,163 @@
+# Single mutation for adding products to cart
+In order to simplify the flow of adding different type of products to wishlist and cart it is proposed to use single mutation for all product types.
+
+*Proposed schema for adding products to cart* - [AddProductsToCart](AddProductsToCart.graphqls)
+
+*Proposed schema for adding products to wish list* - [AddProductsToWishlist](AddProductsToWishlist.graphqls)
+
+## Definition
+
+- Bundle dynamic, grouped and configurable product are just templates which help merchant to select a set of simple products.
+- Product may have selected options and entered options (buyer input).
+- Options are sets of predefined values that a buyer can add to cart/wishlist in addition to a product.
+- Some of the options can be required by its nature but not by API signature.
+- The differences in payloads between wishlist and cart is that all fields in wishlist are optional.
+
+### Examples
+
+#### Add simple product to cart
+```
+[
+  {
+    "sku": "Cup",
+    "qty": 1,
+    "selected_options" : [
+      base64_encode('configurable/24/42')
+    ],
+    "entered_options": [
+      {
+        id: 31,
+        value: base64_encode('Vasia's awesome cup')
+      }
+    ]
+  }
+]
+```
+
+In this example we want to add _personalized blue cup to cart_.
+
+ - `selected_options` - predefined and selected by customer options. `base64` encoding will help to use UUID in future. In this example values will be following:
+
+    | Name  | Value | Real Data |
+    | ------------- | ------------- | ------------- |
+    | option-type  | configurable   |
+    | option-id  | 24 | color |
+    | option-value-id  | 42  | blue |
+- `option-type` - predefined list of option types, e.g. downloadable link, configurable option, bundle option, customizable option.
+- `entered_options` - entered by customer options.
+
+This example is suitable for virtual product and gift card as well.
+
+#### Add downloadable product to cart
+Here `selected_options` contain `<option-type>/<link-id>`.
+```
+[
+  {
+    "sku": "Video tutorial",
+    "qty": 1,
+    "selected_options" : [
+      base64_encode('downloadable/13')
+    ]
+  }
+]
+```
+
+#### Add bundle product to cart
+```
+[
+  {
+    "sku": "Cup",
+    "qty": 1,
+    "parent_sku": "Kit",
+  },
+  {
+    "sku": "Plate",
+    "qty": 1,
+    "parent_sku":  "Kit",
+  }
+]
+```
+
+:warning: If bundle product is added with options, they should be identical for all children:
+```
+[
+  {
+    "sku": "Cup",
+    "qty": 1,
+    "parent_sku": "Kit",
+    "selected_options" : [
+      base64_encode(configurable/42/24)
+    ],
+  },
+  {
+    "sku": "Plate",
+    "qty": 1,
+    "parent_sku": "Kit",
+    "selected_options" : [
+      base64_encode(configurable/42/24)
+    ],
+  },
+]
+```
+
+
+#### Add configurable product to cart
+In this example we want to add _glass blue cup to cart_.
+```
+[
+  {
+    "sku": "Glass Cup",
+    "qty": 1,
+    "selected_options" : [
+      base64_encode(configurable/42/24)
+    ]
+  }
+]
+```
+
+Following approach will work with the partial option selection, for example for wish list purposes.
+```
+[
+  {
+    "sku": "Glass Cup Small",
+    "qty": 1,
+    "parent_sku": "Glass Cup",
+    "selected_options" : [
+      base64_encode(configurable/42/24)
+    ],
+  }
+]
+```
+
+#### Add grouped product to cart
+```
+[
+  {
+    "sku": "Cup Small",
+    "qty": 1.
+  },
+  {
+    "sku": "Cup Big",
+    "qty": 1
+  }
+]
+```
+:warning: Grouped product should be added to cart without parent, but to wish list - with parent.
+Wishlist functionality will preserve the same behaviour with the only difference that all fields are optional.
+
+#### Add product to wishlist
+```
+[
+  {
+    "sku": "Cup",
+    "qty": 1,
+    "entered_options": [
+      {
+        id: 31,
+        value: base64_encode('Vasia's awesome cup')
+      }
+    ]
+  }
+]
+```
+In this example with partial selection, other required options like color should be added when product is moved from wishlist to cart.

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -37,22 +37,22 @@ In this example we want to add _personalized blue cup to cart_ to cart.
 
  - `selected_options` - predefined and selected by customer options. `base64` encoding will help to use UUID in future.
 :warning: The encoded value will be returned from server and should be used by client as is. In order to achieve this:
+
 ``` graphql
 interface CustomizableOptionInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\CustomizableOptionTypeResolver") @doc(description: "The CustomizableOptionInterface contains basic information about a customizable option. It can be implemented by several types of configurable options.") {
     ...
     id: ID @doc(description: "Option ID.")
 }
-
 ```
-
 
 In this example values will be following:
 
-    | Name  | Value | Buyer Selection |
-    | ------------- | ------------- | ------------- |
-    | option-type  | configurable   |
-    | option-id  | 24 | color |
-    | option-value-id  | 42  | blue |
+| Name  | Value | Buyer Selection |
+| ------------- | ------------- | ------------- |
+| option-type  | configurable   |
+| option-id  | 24 | color |
+| option-value-id  | 42  | blue |
+
 - `option-type` - predefined list of option types, e.g. downloadable, configurable, bundle, customizable.
 - `entered_options` - entered by customer (text, image, etc) and encoded options.
 

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -21,12 +21,12 @@ In order to simplify the flow of adding different type of products to wishlist a
     "sku": "Cup",
     "qty": 1,
     "selected_options" : [
-      "Y29uZmlndXJhYmxlLzI0LzQy"
+      "Y29uZmlndXJhYmxlLzI0LzQy" //base64_encode('configurable/24/42')
     ],
     "entered_options": [
       {
-        id: "Y3VzdG9tLW9wdGlvbi8zMQ==",
-        value: "VmFzaWEncyBhd2Vzb21lIGN1cA=="
+        id: "Y3VzdG9tLW9wdGlvbi8zMQ==", //base64_encode("custom-option/31")
+        value: "VmFzaWEncyBhd2Vzb21lIGN1cA==" // base64_encode("Vasia's awesome cup")
       }
     ]
   }
@@ -35,7 +35,9 @@ In order to simplify the flow of adding different type of products to wishlist a
 
 In this example we want to add _personalized blue cup to cart_ to cart.
 
- - `selected_options` - `base64_encode('configurable/24/42')` predefined and selected by customer options. `base64` encoding will help to use UUID in future. In this example values will be following:
+ - `selected_options` - predefined and selected by customer options. `base64` encoding will help to use UUID in future.
+:warning: The encoded value will be returned from server and should be used by client as is.
+In this example values will be following:
 
     | Name  | Value | Buyer Selection |
     | ------------- | ------------- | ------------- |
@@ -44,14 +46,6 @@ In this example we want to add _personalized blue cup to cart_ to cart.
     | option-value-id  | 42  | blue |
 - `option-type` - predefined list of option types, e.g. downloadable, configurable, bundle, customizable.
 - `entered_options` - entered by customer and encoded options.
-```
-"entered_options": [
-  {
-    id: base64_encode("custom-option/31"),
-    value: base64_encode("Vasia's awesome cup")
-  }
-]
-```
 
 This example is suitable for virtual product and gift card as well.
 
@@ -105,12 +99,13 @@ In this example we want to add _100$ gift card_ to cart.
     "sku": "Video tutorial",
     "qty": 1,
     "selected_options" : [
-      "ZG93bmxvYWRhYmxlLzEz"
+      "ZG93bmxvYWRhYmxlLzEz" //base64_encode('downloadable/13')
     ]
   }
 ]
 ```
-Where `selected_options` contain link id: `base64_encode('downloadable/13')` -> `ZG93bmxvYWRhYmxlLzEz`.
+Where `selected_options` contain link id.
+
 #### Add bundle product to cart
 In this example we want to add _dinnerware kit, that contains cup and saucer_ to cart.
 ```

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -10,7 +10,7 @@ In order to simplify the flow of adding different type of products to wishlist a
 - Bundle dynamic, grouped and configurable product are just templates which help merchant to select a set of simple products.
 - Product may have selected options and entered options (buyer input).
 - Options are sets of predefined values that a buyer can add to cart/wishlist in addition to a product.
-- The difference between wishlist and cart payloads is that all fields in wishlist are optional.
+- The difference between wish list and cart payloads is that all fields in wishlist are optional.
 
 ### Examples
 
@@ -36,7 +36,16 @@ In order to simplify the flow of adding different type of products to wishlist a
 In this example we want to add _personalized blue cup to cart_ to cart.
 
  - `selected_options` - predefined and selected by customer options. `base64` encoding will help to use UUID in future.
-:warning: The encoded value will be returned from server and should be used by client as is.
+:warning: The encoded value will be returned from server and should be used by client as is. In order to achieve this:
+``` graphql
+interface CustomizableOptionInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\CustomizableOptionTypeResolver") @doc(description: "The CustomizableOptionInterface contains basic information about a customizable option. It can be implemented by several types of configurable options.") {
+    ...
+    id: ID @doc(description: "Option ID.")
+}
+
+```
+
+
 In this example values will be following:
 
     | Name  | Value | Buyer Selection |
@@ -45,7 +54,7 @@ In this example values will be following:
     | option-id  | 24 | color |
     | option-value-id  | 42  | blue |
 - `option-type` - predefined list of option types, e.g. downloadable, configurable, bundle, customizable.
-- `entered_options` - entered by customer and encoded options.
+- `entered_options` - entered by customer (text, image, etc) and encoded options.
 
 This example is suitable for virtual product and gift card as well.
 


### PR DESCRIPTION
## Problem
Right now we have 7 mutations for adding different types of products to cart. When we started working on wishlist functionality it turned out that we will have to create 14 more mutations (adding to wishlist and moving from wishlist to cart). It leads to overcomplicated flow and does not help to improve developers experience.

## Solution

In order to simplify the flow it is proposed to use single mutation for all product types.

## Proposed schema
``` graphql
input CartItemInput {
    sku: String!
    quantity: Float
    parent_sku: String, 
    selected_options: [String!] # from the predefined set
    entered_options: [EnteredOptionInput!] # user entered options
}

input WishlistItemInput {
    sku: String
    quantity: Float
    parent_sku: String,
    selected_options: [String!]
    entered_options: [EnteredOptionInput!]
}

```
## Requested Reviewers
@paliarush 
@akaplya 
@maghamed
@rogyar  
@antonkril 
@nrkapoor 