### PR TITLE
Added schema changes for cart promotions

### DIFF
--- a/design-documents/graph-ql/coverage/CartPromotions.graphqls
+++ b/design-documents/graph-ql/coverage/CartPromotions.graphqls
@@ -1,0 +1,53 @@
+type Cart{
+
+    /// Deprecated Feilds
+    applied_coupon: applied_coupon @deprecated(reason: "Use CartPromotions.coupons instead ")                               
+    applied_gift_cards: [AppliedGiftCard] @deprecated(reason: "Use CartPrices.gift_cards instead ") 
+    applied_store_credit: AppliedStoreCredit @deprecated(reason: "Use CartPrices.store_credit instead ") 
+
+    available_payment_methods: [AvailablePaymentMethod]
+    billing_address: BillingCartAddress!
+    email: String
+    items: [CartItemInterface]
+    prices: CartPrices
+    selected_payment_method: SelectedPaymentMethod
+    shipping_addresses: [ShippingCartAddress]!
+}
+
+type CartPrices{
+    applied_taxes: [CartTaxItem]
+    grand_total: Money
+    subtotal_excluding_tax: Money
+    subtotal_including_tax: Money
+    subtotal_with_discount_excluding_tax: Money
+
+    /// Deprecated Fields
+    discount: CartDiscount @deprecated(reason: "Use CartPromotions.discounts instead ") 
+
+    //New Fields
+    discounts: CartPromotions
+    gift_cards: [AppliedGiftCards]
+    store_credit: AppliedStoreCredit
+    
+}
+
+type Discount{
+    amount: Money!
+    label: String!
+}
+
+//New Type
+type CartPromotions{
+  discounts: [Discount] @doc(description: "Shows discount breakdown at Cart level")
+  coupons: [AppliedCoupon]
+  
+}
+type CartItemPrices
+{
+    price: Money!
+    row_total: Money!
+    row_total_including_tax: Money!
+
+    //New Fields - To show discount breakdown at item level
+    discounts: [Discount]
+}

--- a/design-documents/graph-ql/coverage/CartPromotions.graphqls
+++ b/design-documents/graph-ql/coverage/CartPromotions.graphqls
@@ -1,10 +1,13 @@
 type Cart{
 
-    /// Deprecated Feilds
-    applied_coupon: applied_coupon @deprecated(reason: "Use CartPromotions.coupons instead ")                               
-    applied_gift_cards: [AppliedGiftCard] @deprecated(reason: "Use CartPrices.gift_cards instead ") 
-    applied_store_credit: AppliedStoreCredit @deprecated(reason: "Use CartPrices.store_credit instead ") 
+    // Deprecated Fields
+    applied_coupon: applied_coupon @deprecated(reason: "Use applied_coupons instead ")
+    // New field 
+    applied_coupons: [AppliedCoupon]     
 
+    // Unchanged Fields
+    applied_gift_cards: [AppliedGiftCard]
+    applied_store_credit: AppliedStoreCredit
     available_payment_methods: [AvailablePaymentMethod]
     billing_address: BillingCartAddress!
     email: String
@@ -22,13 +25,10 @@ type CartPrices{
     subtotal_with_discount_excluding_tax: Money
 
     /// Deprecated Fields
-    discount: CartDiscount @deprecated(reason: "Use CartPromotions.discounts instead ") 
+    discount: CartDiscount @deprecated(reason: "Use discounts instead ") 
 
-    //New Fields
-    discounts: CartPromotions
-    gift_cards: [AppliedGiftCards]
-    store_credit: AppliedStoreCredit
-    
+    //New Field
+    discounts: [Discount]
 }
 
 type Discount{
@@ -36,12 +36,6 @@ type Discount{
     label: String!
 }
 
-//New Type
-type CartPromotions{
-  discounts: [Discount] @doc(description: "Shows discount breakdown at Cart level")
-  coupons: [AppliedCoupon]
-  
-}
 type CartItemPrices
 {
     price: Money!


### PR DESCRIPTION
## Problem

- To provide discount descriptions with discount label and discount amount pair for all individual discounts applied both at Cart level and CartItem level. 
- Update schema to allow applying multiple coupons per cart

## Solution

Cart discounts can be Applied at Different levels. 

1. Percentage of Product Price
2. Fixed amount in Product Price
3. Percentage of whole cart price
4. Buy X and get Y free

In the current implementation all the discounts applied at the cart are available as an array of labels at CartPrices.discount, without a breakdown of rule label and discount amount.
In order to reflect these price breakdown at Cart the following schema changes are proposed



```
type Cart{

    // Deprecated Fields
    applied_coupon: applied_coupon @deprecated(reason: "Use applied_coupons instead ")
    // New field 
    applied_coupons: [AppliedCoupon]     

    // Unchanged Fields
    applied_gift_cards: [AppliedGiftCard]
    applied_store_credit: AppliedStoreCredit
    available_payment_methods: [AvailablePaymentMethod]
    billing_address: BillingCartAddress!
    email: String
    items: [CartItemInterface]
    prices: CartPrices
    selected_payment_method: SelectedPaymentMethod
    shipping_addresses: [ShippingCartAddress]!
}

type CartPrices{
    applied_taxes: [CartTaxItem]
    grand_total: Money
    subtotal_excluding_tax: Money
    subtotal_including_tax: Money
    subtotal_with_discount_excluding_tax: Money

    /// Deprecated Fields
    discount: CartDiscount @deprecated(reason: "Use discounts instead ") 

    //New Field
    discounts: [Discount]
}

type Discount{
    amount: Money!
    label: String!
}

type CartItemPrices
{
    price: Money!
    row_total: Money!
    row_total_including_tax: Money!

    //New Fields - To show discount breakdown at item level
    discounts: [Discount]
}
```

## Requested Reviewers
@buskamuza 
@paliarush 
@cpartica 

