### PR TITLE
Add GraphQl schema for receiving Pickup Locations.

### DIFF
--- a/design-documents/graph-ql/coverage/PickupLocations.graphqls
+++ b/design-documents/graph-ql/coverage/PickupLocations.graphqls
@@ -1,0 +1,71 @@
+type Query {
+    pickup_locations (
+        distance: DistanceFilterInput,
+        filter: PickupLocationFilterInput,
+        sort: PickupLocationSortInput,
+        page_size: Int = 20,
+        current_page: Int = 1
+    ): PickupLocations
+}
+
+input DistanceFilterInput {
+    radius: Int!
+    country_code: String!
+    region: String
+    city: String
+    postcode: String
+}
+
+input PickupLocationFilterInput {
+    name: FilterTypeInput
+    pickup_location_code: FilterTypeInput
+    country_id: FilterTypeInput
+    postcode: FilterTypeInput
+    region: FilterTypeInput
+    region_id: FilterTypeInput
+    city: FilterTypeInput
+    street: FilterTypeInput
+}
+
+input PickupLocationSortInput {
+    name: SortEnum
+    pickup_location_code: SortEnum
+    distance: SortEnum
+    country_id: SortEnum
+    region: SortEnum
+    region_id: SortEnum
+    city: SortEnum
+    street: SortEnum
+    postcode: SortEnum
+    longitude: SortEnum
+    latitude: SortEnum
+    email: SortEnum
+    fax: SortEnum
+    phone: SortEnum
+    contact_name: SortEnum
+    description: SortEnum
+}
+
+type PickupLocations {
+    items: [PickupLocation]
+    page_info: SearchResultPageInfo
+    total_count: Int
+}
+
+type PickupLocation {
+    pickup_location_code: String
+    name: String
+    email: String
+    fax: String
+    contact_name: String
+    description: String
+    latitude: Float
+    longitude: Float
+    country_id: String
+    region_id: Int
+    region: String
+    city: String
+    street: String
+    postcode: String
+    phone: String
+}

--- a/design-documents/graph-ql/coverage/PickupLocations.graphqls
+++ b/design-documents/graph-ql/coverage/PickupLocations.graphqls
@@ -1,10 +1,10 @@
 type Query {
-    pickup_locations (
+    pickupLocations (
         distance: DistanceFilterInput,
         filter: PickupLocationFilterInput,
         sort: PickupLocationSortInput,
-        page_size: Int = 20,
-        current_page: Int = 1
+        pageSize: Int = 20,
+        currentPage: Int = 1
     ): PickupLocations
 }
 


### PR DESCRIPTION
GraphQl Schema for receiving Pickup Locations (in the scope of In-Store Pickup implementation).

### Proposed Schema
```
type Query {
    pickupLocations (
        distance: DistanceFilterInput,
        filter: PickupLocationFilterInput,
        sort: PickupLocationSortInput,
        pageSize: Int = 20,
        currentPage: Int = 1
    ): PickupLocations
}
```
Proposed Schema is to be similar with `Catalog.Products` GraphQl Schema and to `GetPickupLocations` webapi endpoint.
List of arguments:
- distance - special filter of Pickup Locations by distance to the entered address;
- filter - filter by Pickup Location entity attributes;
- sort - sorting of the return collection;
- page_size - the size of the collection page;
- current_page - number of the page which will be returned;

```
input DistanceFilterInput {
    radius: Int!
    country_code: String!
    region: String
    city: String
    postcode: String
}
```
Input type for distance filter:
- radius - radius for the distance search
- country_code - country for the search
- region
- city
- postcode

```
input PickupLocationFilterInput {
    name: FilterTypeInput
    pickup_location_code: FilterTypeInput
    country_id: FilterTypeInput
    postcode: FilterTypeInput
    region: FilterTypeInput
    region_id: FilterTypeInput
    city: FilterTypeInput
    street: FilterTypeInput
}
```
Input type for set of attribute filters.
Uses `FilterTypeInput` from the app/code/Magento/GraphQl/etc/schema.graphqls
```
input PickupLocationSortInput {
    name: SortEnum
    pickup_location_code: SortEnum
    distance: SortEnum
    country_id: SortEnum
    region: SortEnum
    region_id: SortEnum
    city: SortEnum
    street: SortEnum
    postcode: SortEnum
    longitude: SortEnum
    latitude: SortEnum
    email: SortEnum
    fax: SortEnum
    phone: SortEnum
    contact_name: SortEnum
    description: SortEnum
}
```
Input for sort orders. Uses `SortEnum` from app/code/Magento/GraphQl/etc/schema.graphqls

```
type PickupLocations {
    items: [PickupLocation]
    page_info: SearchResultPageInfo
    total_count: Int
}
```
Top level object, result of the Pickup Locations Search.

```
type PickupLocation {
    pickup_location_code: String
    name: String
    email: String
    fax: String
    contact_name: String
    description: String
    latitude: Float
    longitude: Float
    country_id: String
    region_id: Int
    region: String
    city: String
    street: String
    postcode: String
    phone: String
}
```
Definition for Pickup Location type. Include attributes, which can be received with `GetPickupLocations` webapi endpoint.

Link to the PR: https://github.com/magento/inventory/pull/2525/

## Requested Reviewers
@paliarush @maghamed