### PR TITLE
Changes to Product pricing in schema

### DIFF
--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -3,7 +3,7 @@ interface ProductInterface{
     price: ProductPrices @deprecated (use price_range)
     price_range: PriceRange!
     tier_price: Float @deprecated (use tier_prices)
-    tier_prices: [ProductTierPrice] #TODO this changes output type. not backwards-compatible
+    tier_prices: [TierPrice] #TODO this changes output type. not backwards-compatible
     ...
 }
 
@@ -13,15 +13,15 @@ type ProductPrices { @deprecated (use PriceRange)
     regularPrice: @deprecated
 }
 
-type ProductTierPrices @deprecated (replaced by ProductTierPrice because it should be singular) {
+type ProductTierPrices @deprecated (replaced by TierPrice because it should be singular) {
     customer_group_id: String @deprecated (not relevant on storefront)
-    qty: Float @deprecated (use ProductTierPrice.quantity)
-    value: Float @deprecated (use ProductTierPrice.final_price)
-    percentage_value: Float @deprecated (use ProductTierPrice.discount)
+    qty: Float @deprecated (use TierPrice.quantity)
+    value: Float @deprecated (use TierPrice.final_price)
+    percentage_value: Float @deprecated (use TierPrice.discount)
     website_id: Float @deprecated (not relevant on storefront)
 }
 
-type ProductTierPrice {
+type TierPrice {
     final_price: Money
     quantity: Float
     discount: ProductDiscount

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -37,7 +37,7 @@ type ProductPrice{
     regular_price : Money!
     final_price : Money!
     discount : ProductDiscount
-    fixed_product_tax: [FixedProductTax]
+    fixed_product_taxes: [FixedProductTax]
 }
 
 type ProductDiscount{

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -29,8 +29,8 @@ type PriceRange{
 }
 
 type ProductPrice{
-    regular_price : Money!
-    final_price : Money!
+    regular_price : Price!
+    final_price : Price!
     discount : ItemDiscount
 }
 
@@ -39,8 +39,14 @@ type ProductDiscount{
     amount_off : Float
 }
 
+#No changes, just for reference
+
+type Price @doc(description: "The Price object defines the price of a product as well as any tax-related adjustments.") {
+    amount: Money @doc(description: "The price of a product plus a three-letter currency code.")
+    adjustments: [PriceAdjustment] @doc(description: "An array that provides information about tax, weee, or weee_tax adjustments.")
+}
+
 type Money{
     value : Float!
     currency : Currency!
 }
-

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -14,13 +14,13 @@ type ProductPrices { @deprecated (use PriceRange)
 }
 
 type ProductTierPrices {
-    customer_group_id: String
+    customer_group_id: String @deprecated (not relevant on storefront)
     qty: Float
     value: Float @deprecated (use final_price)
     final_price: Money
     percentage_value: Float @deprecated (use discount)
     discount: ProductDiscount
-    website_id: Float
+    website_id: Float @deprecated (not relevant on storefront)
 }
 
 type PriceRange{

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -50,3 +50,20 @@ type Money{
     value : Float!
     currency : Currency!
 }
+
+type PriceAdjustment @doc(description: "The PricedAdjustment object defines the amount of money to apply as an adjustment, the type of adjustment to apply, and whether the item is included or excluded from the adjustment.") {
+    amount: Money @doc(description: "The amount of the price adjustment and its currency code.")
+    code: PriceAdjustmentCodesEnum @doc(description: "Indicates whether the adjustment involves tax, weee, or weee_tax.")
+    description: PriceAdjustmentDescriptionEnum @doc(description: "Indicates whether the entity described by the code attribute is included or excluded from the adjustment.")
+}
+
+enum PriceAdjustmentCodesEnum @doc(description: "Note: This enumeration contains values defined in modules other than the Catalog module.") {
+    # From WeeGraphQl
+    WEE
+    WEETAX
+}
+
+enum PriceAdjustmentDescriptionEnum @doc(description: "This enumeration states whether a price adjustment is included or excluded.") {
+    INCLUDED
+    EXCLUDED
+}

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -2,8 +2,9 @@ interface ProductInterface{
     ...
     price: ProductPrices @deprecated (use price_range)
     price_range: PriceRange!
-    tier_price: Float @deprecated (use tier_prices)
-    tier_prices: [TierPrice] #TODO this changes output type. not backwards-compatible
+    tier_price: Float @deprecated
+    tier_prices: [ProductTierPrices] @deprecated (use price_tiers)
+    price_tiers: [TierPrice]
     ...
 }
 

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -19,7 +19,7 @@ type ProductTierPrices {
     value: Float @deprecated (use final_price)
     final_price: Money
     percentage_value: Float @deprecated (use discount)
-    discount: ItemDiscount
+    discount: ProductDiscount
     website_id: Float
 }
 
@@ -31,7 +31,7 @@ type PriceRange{
 type ProductPrice{
     regular_price : Price!
     final_price : Price!
-    discount : ItemDiscount
+    discount : ProductDiscount
 }
 
 type ProductDiscount{

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -1,0 +1,46 @@
+interface ProductInterface{
+    ...
+    price: ProductPrices @deprecated (use price_range)
+    price_range: PriceRange!
+    tier_price: Float @deprecated (use tier_prices)
+    tier_prices: [ProductTierPrices]
+    ...
+}
+
+type ProductPrices { @deprecated (use PriceRange)
+    minimalPrice: @deprecated
+    maximalPrice: @deprecated
+    regularPrice: @deprecated
+}
+
+type ProductTierPrices {
+    customer_group_id: String
+    qty: Float
+    value: Float @deprecated (use final_price)
+    final_price: Money
+    percentage_value: Float @deprecated (use discount)
+    discount: ItemDiscount
+    website_id: Float
+}
+
+type PriceRange{
+    minimum_price : ProductPrice!
+    maximum_price : ProductPrice
+}
+
+type ProductPrice{
+    regular_price : Money!
+    final_price : Money!
+    discount : ItemDiscount
+}
+
+type ProductDiscount{
+    percent_off : Float
+    amount_off : Float
+}
+
+type Money{
+    value : Float!
+    currency : Currency!
+}
+

--- a/design-documents/graph-ql/coverage/ProductPrices.graphqls
+++ b/design-documents/graph-ql/coverage/ProductPrices.graphqls
@@ -3,7 +3,7 @@ interface ProductInterface{
     price: ProductPrices @deprecated (use price_range)
     price_range: PriceRange!
     tier_price: Float @deprecated (use tier_prices)
-    tier_prices: [ProductTierPrices]
+    tier_prices: [ProductTierPrice] #TODO this changes output type. not backwards-compatible
     ...
 }
 
@@ -13,14 +13,18 @@ type ProductPrices { @deprecated (use PriceRange)
     regularPrice: @deprecated
 }
 
-type ProductTierPrices {
+type ProductTierPrices @deprecated (replaced by ProductTierPrice because it should be singular) {
     customer_group_id: String @deprecated (not relevant on storefront)
-    qty: Float
-    value: Float @deprecated (use final_price)
-    final_price: Money
-    percentage_value: Float @deprecated (use discount)
-    discount: ProductDiscount
+    qty: Float @deprecated (use ProductTierPrice.quantity)
+    value: Float @deprecated (use ProductTierPrice.final_price)
+    percentage_value: Float @deprecated (use ProductTierPrice.discount)
     website_id: Float @deprecated (not relevant on storefront)
+}
+
+type ProductTierPrice {
+    final_price: Money
+    quantity: Float
+    discount: ProductDiscount
 }
 
 type PriceRange{
@@ -29,9 +33,10 @@ type PriceRange{
 }
 
 type ProductPrice{
-    regular_price : Price!
-    final_price : Price!
+    regular_price : Money!
+    final_price : Money!
     discount : ProductDiscount
+    fixed_product_tax: [FixedProductTax]
 }
 
 type ProductDiscount{
@@ -39,31 +44,34 @@ type ProductDiscount{
     amount_off : Float
 }
 
-#No changes, just for reference
-
-type Price @doc(description: "The Price object defines the price of a product as well as any tax-related adjustments.") {
-    amount: Money @doc(description: "The price of a product plus a three-letter currency code.")
-    adjustments: [PriceAdjustment] @doc(description: "An array that provides information about tax, weee, or weee_tax adjustments.")
+type FixedProductTax {
+    amount: Money
+    label: String
 }
 
-type Money{
-    value : Float!
-    currency : Currency!
+type Price @deprecated (replaced by ProductPrice){
+    amount: Money
+    adjustments: [PriceAdjustment]
 }
 
-type PriceAdjustment @doc(description: "The PricedAdjustment object defines the amount of money to apply as an adjustment, the type of adjustment to apply, and whether the item is included or excluded from the adjustment.") {
-    amount: Money @doc(description: "The amount of the price adjustment and its currency code.")
-    code: PriceAdjustmentCodesEnum @doc(description: "Indicates whether the adjustment involves tax, weee, or weee_tax.")
-    description: PriceAdjustmentDescriptionEnum @doc(description: "Indicates whether the entity described by the code attribute is included or excluded from the adjustment.")
+type PriceAdjustment @deprecated (replaced by FixedProductTax) {
+    amount: Money
+    code: PriceAdjustmentCodesEnum
+    description: PriceAdjustmentDescriptionEnum
 }
 
-enum PriceAdjustmentCodesEnum @doc(description: "Note: This enumeration contains values defined in modules other than the Catalog module.") {
+enum PriceAdjustmentCodesEnum @deprecated (replaced by FixedProductTax) {
     # From WeeGraphQl
     WEE
     WEETAX
 }
 
-enum PriceAdjustmentDescriptionEnum @doc(description: "This enumeration states whether a price adjustment is included or excluded.") {
+enum PriceAdjustmentDescriptionEnum @deprecated (replaced by FixedProductTax) {
     INCLUDED
     EXCLUDED
+}
+
+type Money{
+    value : Float!
+    currency : Currency!
 }


### PR DESCRIPTION
## Problem
The current pricing schema has some inconsistencies and the structure is not ideal for conveying all price data (e.g. discounts).

## Solution
The goal of refactoring the product pricing schema is to provide a more consistent structure for product price information.

#### Changes:

- Type ProductInterface: existing type, with some field changes
  - price: deprecated because it will be replaced by price_range
  - price_range: new field, represents the min and max price of the product.
  - tier_price: deprecated
  - tier_prices: deprecated (use price_tiers)
  - price_tiers: new field to hold tier price data. Added new field because type is different (TierPrice)
- Type ProductPrices; deprecated, replaced by PriceRange
- Type PriceRange: new type (type for ProductInterface.price_range)
  - minimum_price: The minimum price of the product (e.g. the base price of a product with no custom options applied)
  - maximum_price: The maximum price of the product (e.g. with most expensive options applied)
- Type ProductPrice: new type (type for PriceRange.minimum/maximum_price)
  - regular_price: The regular price of the product
  - final_price: The price of the product after discounts and things that change price
  - discounts: Product discount; reflects difference between regular and final price
- Type ProductDiscount: new type (type for price discounts on products)
  - percent_off: the price difference represented as a percentage
  - amount_off: the price difference represented as a dollar value
- Type FixedProductTax: new type for taxes in catalog
- Type ProductTierPrices: deprecated (replaced by TierPrice)
- Type TierPrice: new type for ProductInterface.price_tiers
- Type Price (deprecated, replaced ProductPrice)
- Type PriceAdjustment, PriceAdjustmentCodesEnum, PriceAdjustmentDescriptionEnum deprecated, replaced by FixedProductTax (ProductPrice.fixed_product_tax)

## Requested Reviewers
@paliarush 
@akaplya 
@kokoc 