### PR TITLE
GraphQL cart error messages

### DIFF
--- a/design-documents/graph-ql/coverage/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/Cart.graphqls
@@ -27,6 +27,8 @@ type Cart {
 
     is_multishipping: Boolean!
     is_virtual: Boolean!
+
+    errors: [CartError]
 }
 
 type CheckoutCustomer {
@@ -56,4 +58,9 @@ type CheckoutPaymentMethod {
 
 type CartGiftCard {
     code: String!
+}
+
+type CartError {
+    identifier: String
+    text: String
 }


### PR DESCRIPTION
## Problem
Now in GraphQL when multiple errors occur with cart there is no way to read all cart messages in order to understand the whole context.  
![53808295-8c011b00-3f5a-11e9-9372-d84fb4464e89](https://user-images.githubusercontent.com/17548019/65539422-05e4fb80-decf-11e9-99f5-988d0fee4658.png)

## Solution
@XxXgeoXxX proposes to add additional filed to the `Cart` type https://github.com/magento/graphql-ce/pull/475
Names changed by me but, PR will be adjusted once approved here.

## Requested Reviewers
@paliarush 
