### PR TITLE
Changes to Category Query in schema for filtering.

### DIFF
--- a/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
+++ b/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
@@ -1,21 +1,15 @@
-type Query {
-   category (
-   id: Int @doc(description: "Id of the category.")
 
-   # added Category filter input.
-   filter: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
-   ): CategoryTree
-    @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree") @doc(description: "The category query searches for categories that match the criteria specified in the search and filter attributes.") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoryTreeIdentity")
-}
+ # added Category List Query.
+
+type Query CategoryList(
+filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
+): [CategoryTree] @doc(description: "Categories tree.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
 
 # added CategoryFilterInput with id, url_key and name as input filters.
 
-input CategoryFilterInput @doc(description: "CategoryFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.") {
-    id: FilterEqualTypeInput @doc(description: "Filter by category ID that uniquely identifies and filters the category."),
+input CategoryFilterInput  @doc(description: "CategoryFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.")
+{
+    ids: FilterEqualTypeInput @doc(description: "Filter by category ID that uniquely identifies and filters the category."),
     url_key: FilterEqualTypeInput @doc(description: "Filter by the part of the URL that identifies the category"),
-    name: FilterEqualTypeInput @doc(description: "Filter by the display name of the category.")
-}
-
-type CategoryTree implements CategoryInterface @doc(description: "Category Tree implementation.") {
-    children: [CategoryTree] @doc(description: "Child categories tree.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
+    name: FilterMatchTypeInput @doc(description: "Filter by the display name of the category.")
 }

--- a/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
+++ b/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
@@ -1,0 +1,21 @@
+type Query {
+   category (
+   id: Int @doc(description: "Id of the category.")
+
+   # added Category filter input.
+   filter: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
+   ): CategoryTree
+    @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree") @doc(description: "The category query searches for categories that match the criteria specified in the search and filter attributes.") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoryTreeIdentity")
+}
+
+# added CategoryFilterInput with id, url_key and name as input filters.
+
+input CategoryFilterInput @doc(description: "CategoryFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.") {
+    id: FilterEqualTypeInput @doc(description: "Filter by category ID that uniquely identifies and filters the category."),
+    url_key: FilterEqualTypeInput @doc(description: "Filter by the part of the URL that identifies the category"),
+    name: FilterEqualTypeInput @doc(description: "Filter by the display name of the category.")
+}
+
+type CategoryTree implements CategoryInterface @doc(description: "Category Tree implementation.") {
+    children: [CategoryTree] @doc(description: "Child categories tree.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
+}


### PR DESCRIPTION
Added proposal for category filtering changes in CatalogGraphQl/schema.graphqls

## Problem

The current category query schema does not allow filtering with category url or name or id and  also doesn't work with multiple categories.

## Solution

The goal is to add filter on the schema to return the same data with category id, category url or category name and also able to query on multiple categories

## changes:
 // added Category filter input.
   filter: CategoryFilterInput to Query CategoryList

 type Query CategoryList(
filters: CategoryFilterInput
): [CategoryTree]

input CategoryFilterInput
{
ids: FilterEqualTypeInput,
url_key: FilterEqualTypeInput,
name: FilterMatchTypeInput
} 

## Requested Reviewers
@paliarush 
@akaplya 
