### PR TITLE
DB Information Schema - COLUMNS

### DIFF
--- a/design-documents/database/declarative-schema-database-compatibility.md
+++ b/design-documents/database/declarative-schema-database-compatibility.md
@@ -65,7 +65,7 @@ abstract class InformationSchema\Table\Column
     public function getIsNullable(): bool {}
     public function getExtra(): Extra {}
     public function getComment() {}
-    public function getDefaultValue(): string {}
+    public function getDefaultValue(): ?string {}
 }
 ```
 
@@ -198,8 +198,6 @@ It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariad
 ## Considerations
 
 `\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.
-
-`engine` field in declarative schema need to be deprecated.
 
 ## Resources
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -1,0 +1,45 @@
+# Declarative schema database compatibility
+
+## About
+
+Declarative schema relies on querying data that may have different format depending on database. For example, here is the query from `Magento\Framework\Setup\Declaration\Schema\Db\MySQL\DbSchemaReader::readColumns`
+
+```
+SELECT 
+	COLUMN_NAME as 'name',
+	COLUMN_DEFAULT as 'default',
+	DATA_TYPE as 'type',
+	IS_NULLABLE as 'nullable',
+	COLUMN_TYPE as 'definition',
+	EXTRA as 'extra',
+	COLUMN_COMMENT as 'comment'
+FROM
+    information_schema.COLUMNS
+WHERE
+    TABLE_SCHEMA = 'magento'
+AND
+    TABLE_NAME = 'store_website'
+ORDER BY
+    ORDINAL_POSITION ASC;
+```
+
+MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
+
+## Design
+
+Introduce concept of database adapters to allow normalize values in declarative schema for different databases.
+
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Schema\Db\MySQL\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Schema\Db\MySQL\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+
+Similar approach need to be taken for clients of the following interfaces
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface`
+
+Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
+
+`\Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface` currently returns instance of `Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface` that is defined by preference, similarly to approach above it should resolve database specific adapter based on configuration.
+
+`model` is the name of parameter that supposed to be used to configure database specific adapters. Somehow functionality behind it is absent.
+
+It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariadb` and have `mysql4` be alias for `mysql`.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -43,3 +43,7 @@ Not needed for declarative schema, but with this refactoring would also make sen
 `model` is the name of parameter that supposed to be used to configure database specific adapters. Somehow functionality behind it is absent.
 
 It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariadb` and have `mysql4` be alias for `mysql`.
+
+## Considerations
+
+`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. Ideally we should have an interface that would return normalized data and be compatible with all databases. This is a much larger change and might be considered for minor release.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -29,7 +29,7 @@ MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
 
 Introduce concept of database adapters to allow normalize values in declarative schema for different databases.
 
-`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Schema\Db\MySQL\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Schema\Db\MySQL\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
 
 Similar approach need to be taken for clients of the following interfaces
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -50,8 +50,6 @@ class InformationSchema\Table
 ```
 Note: auto increment is omitted intentionally. Auto increment should not be used for the application logic.
 
-Those classes duplicate already existing ones in `lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns`
-
 ```
 class InformationSchema\Extra
 {
@@ -64,23 +62,29 @@ abstract class InformationSchema\Table\Column
 {
     public function getTableName(): string {}
     public function getName(): string {}
-    public function getType(): string {}
     public function getIsNullable(): bool {}
     public function getExtra(): Extra {}
     public function getComment() {}
     public function getDefaultValue(): string {}
-    public function getCharLength(): ?int {} // for string only
-    public function getCharsetName(): string {} // for string only
-    public function getCollationName(): string {} // for string only
-    public function getPrecision(): ?int {} // for int/dec only
-    public function getNumericScale(): ?int {} // for int/dec only
-    public function getDatetimePrecision(): ?int {} // for temporal only
 }
 ```
 
 ```
-class InformationSchema\Table\IntegerColumn extends Column
+class InformationSchema\Table\VarcharColumn extends Column
 {
+    public const TYPE = 'VARCHAR';
+
+    public function getCharLength(): int {}
+    public function getCharsetName(): string {}
+    public function getCollationName(): string {}
+}
+```
+
+```
+class InformationSchema\Table\IntColumn extends Column
+{
+    public const TYPE = 'INT';
+
     public function isUnsigned(): bool {}
     public function getPadding(): int {}
     public function getType(): IntEnum {}
@@ -88,18 +92,24 @@ class InformationSchema\Table\IntegerColumn extends Column
 ```
 
 ```
-class InformationSchema\Table\DecimalColumn extends Column
+class InformationSchema\Table\FloatColumn extends Column
 {
+    public const TYPE = 'FLOAT';
+
     public function getDefaultValue() {}
     public function getScale(): int {}
     public function getPrecision(): int {}
+    public function getNumericScale(): int {}
 }
 ```
 
 ```
-class InformationSchema\Table\DateTimeColumn extends Column
+class InformationSchema\Table\DateColumn extends Column
 {
+    public const TYPE = 'DATE';
+
     public function getDefaultValue(): string {}
+    public function getDatetimePrecision(): int {}
 }
 ```
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -27,14 +27,274 @@ MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
 
 ## Design
 
-Introduce concept of database adapters to allow normalize values in declarative schema for different databases.
-
-`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+Introduce new interfaces under Db namespace that allow to manage table schema, refactor implementations of the following interfaces in declarative schema to use interfaces under Db namespace.
 
 Similar approach need to be taken for clients of the following interfaces
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+
+Revise implementation of these interfaces to see if anything need to be changed here
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
+
+New interfaces and types for managing table schema.
+
+```
+class ConstraintType extends \SplEnum
+{
+    const primary = 'primary';
+    const unique = 'unique';
+    const auto_increment = 'auto_increment';
+}
+```
+
+```
+class IndexType extends \SplEnum
+{
+    // For MySQL, Oracle and Postgres will use btree
+    const normal = 'normal';
+
+    // For MySQL fulltext, one of text indexes for Oracle and text for Postgres
+    const text = 'text';
+}
+```
+
+```
+class OnDelete extends \SplEnum
+{
+    const cascade = 'cascade';
+}
+```
+
+```
+class CollationType extends \SplEnum
+{
+    const utf8 = 'utf8';
+}
+```
+
+```
+class Constraint
+{
+    public function getName(): string {}
+
+    /**
+     * @return string[]
+     */
+    public function getColumns() {}
+
+    public function getType(): ConstraintType {}
+}
+```
+
+```
+class Index
+{
+    public function getName(): string {}
+
+    /**
+     * @return string[]
+     */
+    public function getColumns() {}
+
+    public function getType(): IndexType {}
+}
+```
+
+```
+class ForeignKey
+{
+    public function getType(): string {}
+    public function getName(): string {}
+    public function getColumn(): string {}
+    public function getReferenceTable(): string {}
+    public function getReferenceColumn(): string {}
+    public function getOnDelete(): OnDelete {}
+}
+```
+
+```
+/**
+ * There is no option for engine. Do we want to support different engines, if so how to abstract them, normal/memory?
+ */
+class TableOptions
+{
+    public function getName(): string {}
+    public function getComment(): string {}
+
+    /**
+     * Potentially can be removed as well?
+     */
+    public function getCollation(): CollationType {}
+}
+```
+
+```
+class Column
+{
+    public function getName(): string {}
+    public function getType() {}
+    public function getIsNullable() {}
+    public function getExtra() {}
+    public function getComment() {}
+}
+```
+
+```
+class IntegerColumn extends Column
+{
+    public function getDefaultValue() {}
+    public function isUnsigned(): bool {}
+    public function getPadding(): int {}
+}
+```
+
+```
+class DecimalColumn extends Column
+{
+    public function getDefaultValue() {}
+    public function getScale(): int {}
+    public function getPrecision(): int {}
+}
+```
+
+```
+class DateTimeColumn extends Column
+{
+    public function getDefaultValue(): string {}
+}
+```
+
+```
+interface TableInformationInterface
+{
+    /**
+     * @return Constraint[]
+     */
+    public function getConstraints($tableName, $resource);
+
+    /**
+     * @return ForeignKey[]
+     */
+    public function getReferences($tableName, $resource);
+
+    /**
+     * @return Index[]
+     */
+    public function getIndexes($tableName, $resource);
+
+    /**
+     * @return Column
+     */
+    public function getColumns($tableName, $resource);
+
+    public function getTableOptions($tableName, $resource): TableOptions;
+}
+```
+
+```
+interface TableManagementInterface
+{
+    public function createTable(TableOptions $tableOptions, $resource);
+    public function dropTable($tableName, $resource);
+
+    /**
+     * @param string $tableName
+     * @param Column|IntegerColumn|DecimalColumn|DateTimeColumn $column
+     * @param $resource
+     */
+    public function addColumn($tableName, Column $column, $resource);
+    public function dropColumn($tableName, $columnName, $resource);
+    public function addIndex($tableName, Index $index, $resource);
+    public function dropIndex($tableName, $indexName, $resource);
+    public function addConstraint($tableName, Constraint $constraint, $resource);
+    public function dropConstraint($tableName, $constraintName, $resource);
+    public function addForeignKey($tableName, ForeignKey $foreignKey, $resource);
+    public function dropForeignKey($tableName, $foreignKeyName, $resource);
+    public function updateTableOptions($tableName, TableOptions $tableOptions, $resource);
+}
+```
+
+```
+class TableDiff
+{
+    public function getName(): string {}
+
+    /**
+     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
+     */
+    public function getAddedColumns() {}
+
+    /**
+     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
+     */
+    public function getChangedColumns() {}
+
+    /**
+     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
+     */
+    public function getRemovedColumns() {}
+
+    /**
+     * Index[]
+     */
+    public function getAddedIndexes() {}
+
+    /**
+     * Index[]
+     */
+    public function getChangedIndexes() {}
+
+    /**
+     * Index[]
+     */
+    public function getRemovedIndexes() {}
+
+    /**
+     * Constraint[]
+     */
+    public function getAddedConstraints() {}
+
+    /**
+     * Constraint[]
+     */
+    public function getChangedConstraints() {}
+
+    /**
+     * Constraint[]
+     */
+    public function getRemovedConstraints() {}
+
+    /**
+     * ForeignKey[]
+     */
+    public function getAddedForeignKeys() {}
+
+    /**
+     * ForeignKey[]
+     */
+    public function getChangedForeignKeys() {}
+
+    /**
+     * ForeignKey[]
+     */
+    public function getRemovedForeignKeys() {}
+
+    public function getFromTable(): string {}
+}
+```
+
+```
+/**
+ * Alternative interface
+ */
+interface TableManagementInterface
+{
+    public function createTable(TableOptions $tableOptions, $resource);
+    public function dropTable($tableName, $resource);
+    public function alterTable($tableName, $resource, TableDiff $tableDiff);
+}
+```
 
 Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
 
@@ -46,4 +306,4 @@ It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariad
 
 ## Considerations
 
-`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. Ideally we should have an interface that would return normalized data and be compatible with all databases. This is a much larger change and might be considered for minor release.
+`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -47,11 +47,9 @@ class ConstraintType extends \SplEnum
 ```
 class IndexType extends \SplEnum
 {
-    // For MySQL, Oracle, MS SQL and Postgres will use btree
-    const normal = 'normal';
+    const btree = 'btree';
 
-    // For MySQL and MS SQL fulltext, one of text indexes for Oracle and text for Postgres
-    const text = 'text';
+    const fulltext = 'fulltext';
 }
 ```
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -113,7 +113,7 @@ class ForeignKey
 /**
  * There is no option for engine. Do we want to support different engines, if so how to abstract them, normal/memory?
  */
-class TableOptions
+class Table
 {
     public function getName(): string {}
     public function getComment(): string {}
@@ -167,17 +167,32 @@ interface InformationSchema\Table\ConstraintInterface
     /**
      * @return Constraint[]
      */
-    public function getConstraints($tableName, $resource);
+    public function getConstraints($tableName, $connectionName);
+
+    /**
+     * @return Constraint
+     */
+    public function getConstraintByName($tableName, $constraintName, $connectionName);
 }
 ```
 
 ```
-interface InformationSchema\Table\ReferenceInterface
+interface InformationSchema\Table\ForeignKeyInterface
 {
     /**
      * @return ForeignKey[]
      */
-    public function getReferences($tableName, $resource);
+    public function getForeignKeys($tableName, $connectionName);
+    
+    /**
+     * @return ForeignKey
+     */
+    public function getForeignKeyByName($tableName, $foreignKeyName, $connectionName);
+    
+    /**
+     * @return ForeignKey[]
+     */
+    public function getForeignKeyForTable($tableName, $connectionName);
 }
 ```
 
@@ -187,7 +202,12 @@ interface InformationSchema\Table\IndexInterface
     /**
      * @return Index[]
      */
-    public function getIndexes($tableName, $resource);
+    public function getIndexes($tableName, $connectionName);
+    
+    /**
+     * @return Index
+     */
+    public function getIndexByName($tableName, $indexName, $connectionName);
 }
 ```
 
@@ -197,14 +217,14 @@ interface InformationSchema\Table\ColumnInterface
     /**
      * @return Column
      */
-    public function getColumns($tableName, $resource);
+    public function getColumns($tableName, $connectionName);
 }
 ```
 
 ```
-interface InformationSchema\Table\OptionsInterface
+interface InformationSchema\TableInterface
 {
-    public function getTableOptions($tableName, $resource): TableOptions;
+    public function getInformation($tableName, $connectionName): Table;
 }
 ```
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -51,10 +51,10 @@ class ConstraintType extends \SplEnum
 ```
 class IndexType extends \SplEnum
 {
-    // For MySQL, Oracle and Postgres will use btree
+    // For MySQL, Oracle, MS SQL and Postgres will use btree
     const normal = 'normal';
 
-    // For MySQL fulltext, one of text indexes for Oracle and text for Postgres
+    // For MySQL and MS SQL fulltext, one of text indexes for Oracle and text for Postgres
     const text = 'text';
 }
 ```
@@ -296,6 +296,19 @@ interface TableManagementInterface
 }
 ```
 
+### Alternative approach
+
+Alternative approach is to reuse existing interfaces and add replaceability on the level of declarative schema.
+
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+
+Similar approach need to be taken for clients of the following interfaces
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
+
+### Replaceability of `\Magento\Framework\DB\Adapter\AdapterInterface`
+
 Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
 
 `\Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface` currently returns instance of `Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface` that is defined by preference, similarly to approach above it should resolve database specific adapter based on configuration.
@@ -307,3 +320,5 @@ It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariad
 ## Considerations
 
 `\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.
+
+`engine` field in declarative schema need to be deprecated.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -27,11 +27,7 @@ MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
 
 ## Design
 
-Introduce new interfaces under Db namespace that allow to manage table schema, refactor implementations of the following interfaces in declarative schema to use interfaces under Db namespace.
-
-Similar approach need to be taken for clients of the following interfaces
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface`
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+Introduce new interfaces under Db namespace that allow to allow get information about table schema, refactor implementations of `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface` in declarative schema to use interfaces under Db namespace.
 
 Revise implementation of these interfaces to see if anything need to be changed here
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
@@ -166,135 +162,53 @@ class DateTimeColumn extends Column
 ```
 
 ```
-interface TableInformationInterface
+interface InformationSchema\Table\ConstraintInterface
 {
     /**
      * @return Constraint[]
      */
     public function getConstraints($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\ReferenceInterface
+{
     /**
      * @return ForeignKey[]
      */
     public function getReferences($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\IndexInterface
+{
     /**
      * @return Index[]
      */
     public function getIndexes($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\ColumnInterface
+{
     /**
      * @return Column
      */
     public function getColumns($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\OptionsInterface
+{
     public function getTableOptions($tableName, $resource): TableOptions;
 }
 ```
 
-```
-interface TableManagementInterface
-{
-    public function createTable(TableOptions $tableOptions, $resource);
-    public function dropTable($tableName, $resource);
-
-    /**
-     * @param string $tableName
-     * @param Column|IntegerColumn|DecimalColumn|DateTimeColumn $column
-     * @param $resource
-     */
-    public function addColumn($tableName, Column $column, $resource);
-    public function dropColumn($tableName, $columnName, $resource);
-    public function addIndex($tableName, Index $index, $resource);
-    public function dropIndex($tableName, $indexName, $resource);
-    public function addConstraint($tableName, Constraint $constraint, $resource);
-    public function dropConstraint($tableName, $constraintName, $resource);
-    public function addForeignKey($tableName, ForeignKey $foreignKey, $resource);
-    public function dropForeignKey($tableName, $foreignKeyName, $resource);
-    public function updateTableOptions($tableName, TableOptions $tableOptions, $resource);
-}
-```
-
-```
-class TableDiff
-{
-    public function getName(): string {}
-
-    /**
-     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
-     */
-    public function getAddedColumns() {}
-
-    /**
-     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
-     */
-    public function getChangedColumns() {}
-
-    /**
-     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
-     */
-    public function getRemovedColumns() {}
-
-    /**
-     * Index[]
-     */
-    public function getAddedIndexes() {}
-
-    /**
-     * Index[]
-     */
-    public function getChangedIndexes() {}
-
-    /**
-     * Index[]
-     */
-    public function getRemovedIndexes() {}
-
-    /**
-     * Constraint[]
-     */
-    public function getAddedConstraints() {}
-
-    /**
-     * Constraint[]
-     */
-    public function getChangedConstraints() {}
-
-    /**
-     * Constraint[]
-     */
-    public function getRemovedConstraints() {}
-
-    /**
-     * ForeignKey[]
-     */
-    public function getAddedForeignKeys() {}
-
-    /**
-     * ForeignKey[]
-     */
-    public function getChangedForeignKeys() {}
-
-    /**
-     * ForeignKey[]
-     */
-    public function getRemovedForeignKeys() {}
-
-    public function getFromTable(): string {}
-}
-```
-
-```
-/**
- * Alternative interface
- */
-interface TableManagementInterface
-{
-    public function createTable(TableOptions $tableOptions, $resource);
-    public function dropTable($tableName, $resource);
-    public function alterTable($tableName, $resource, TableDiff $tableDiff);
-}
-```
+Management interfaces will not be introduced.
 
 ### Alternative approach
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -6,13 +6,13 @@ Declarative schema relies on querying data that may have different format depend
 
 ```
 SELECT 
-	COLUMN_NAME as 'name',
-	COLUMN_DEFAULT as 'default',
-	DATA_TYPE as 'type',
-	IS_NULLABLE as 'nullable',
-	COLUMN_TYPE as 'definition',
-	EXTRA as 'extra',
-	COLUMN_COMMENT as 'comment'
+    COLUMN_NAME as 'name',
+    COLUMN_DEFAULT as 'default',
+    DATA_TYPE as 'type',
+    IS_NULLABLE as 'nullable',
+    COLUMN_TYPE as 'definition',
+    EXTRA as 'extra',
+    COLUMN_COMMENT as 'comment'
 FROM
     information_schema.COLUMNS
 WHERE
@@ -34,7 +34,7 @@ Introduce concept of database adapters to allow normalize values in declarative 
 Similar approach need to be taken for clients of the following interfaces
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
 
 Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
 


### PR DESCRIPTION
## Problem

This is a subset of https://github.com/magento/architecture/pull/264 , covering only COLUMNS and TABLES interfaces.

Different RDBMS return Information Schema (metadata) information in different format. Magento framework should allow to switch between different implementations in order to support those different versions of DBs, as well as differences between versions.

## Solution

Introduce granular interfaces, based in Information Schema standard (looking into MySQL and MariaDB definitions in this scope, links are in the document). Application can switch between different implementation based on the profile.