### PR TITLE
DB Information Schema - COLUMNS

### DIFF
--- a/design-documents/database/declarative-schema-database-compatibility.md
+++ b/design-documents/database/declarative-schema-database-compatibility.md
@@ -65,7 +65,7 @@ abstract class InformationSchema\Table\Column
     public function getIsNullable(): bool {}
     public function getExtra(): Extra {}
     public function getComment() {}
-    public function getDefaultValue(): string {}
+    public function getDefaultValue(): ?string {}
 }
 ```
 
@@ -198,8 +198,6 @@ It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariad
 ## Considerations
 
 `\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.
-
-`engine` field in declarative schema need to be deprecated.
 
 ## Resources
 

--- a/design-documents/database/declarative-schema-database-compatibility.md
+++ b/design-documents/database/declarative-schema-database-compatibility.md
@@ -349,23 +349,6 @@ class InformationSchema\Table\CharColumn extends Column
     public function getDefaultValue(): ?string {}
 }
 ```
-```
-class InformationSchema\Table\NationalCharColumn extends Column
-{
-    /**
-     * Retturns the maximum length in characters.
-     */
-    public function getCharLength(): int {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-Note that MySQL / MariaDB maps this type to `char`.
 
 ```
 class InformationSchema\Table\VarcharColumn extends Column
@@ -387,26 +370,6 @@ class InformationSchema\Table\VarcharColumn extends Column
 ```
 
 ```
-class InformationSchema\Table\NationalVarcharColumn extends Column
-{
-    /**
-     * Returns the maximum length in characters.
-     *
-     * @return int
-     */
-    public function getCharLength(): int {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-Note that MySQL / MariaDB maps this type to `varchar`.
-
-```
 class InformationSchema\Table\ClobColumn extends Column
 {
     /**
@@ -419,64 +382,11 @@ class InformationSchema\Table\ClobColumn extends Column
 ```
 Note that MySQL / MariaDB and PostgreSQL use the type `text` for this purpose.
 
-```
-class InformationSchema\Table\NationalClobColumn extends Column
-{
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-Note that MySQL / MariaDB does not have support for a national type of character large object.
-
 ##### Date/Time types
 
 ```
 class InformationSchema\Table\DateColumn extends Column
 {
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-
-```
-class InformationSchema\Table\TimeColumn extends Column
-{
-    /**
-     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
-     * value).
-     *
-     * @return int|null 
-     */
-    public function getPrecision(): ?int {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-
-```
-class InformationSchema\Table\TimeWithTimezoneColumn extends Column
-{
-    /**
-     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
-     * value).
-     *
-     * @return int|null 
-     */
-    public function getPrecision(): ?int {}
-
     /**
      * Returns the default value of the column.
      *
@@ -506,77 +416,10 @@ class InformationSchema\Table\TimestampColumn extends Column
 }
 ```
 
-```
-class InformationSchema\Table\TimestampWithTimezoneColumn extends Column
-{
-    /**
-     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
-     * value).
-     *
-     * @return int|null 
-     */
-    public function getPrecision(): ?int {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-
-```
-class InformationSchema\Table\IntervalColumn extends Column
-{
-    /**
-     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
-     * value).
-     *
-     * @return int|null 
-     */
-    public function getPrecision(): ?int {}
-
-    /**
-     * Returns the timestamp fields that are stored by interval.
-     */
-    public function getIntervalFields(): string {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-Note that MySQL / MariaDB does not support the `interval` type but rather suggests to use the `time` type which is 
-limited compared to `interval` as it can only store the range '-838:59:59.000000' to '838:59:59.000000' (roughly 
-equivalent to `interval MONTH`).
-
 ##### Binary types
 
 ```
 class InformationSchema\Table\BinaryColumn extends Column
-{
-    /**
-     * Returns the maximum length in bytes.
-     *
-     * @return int
-     */
-    public function getByteLength(): int {}
-
-    /**
-     * Returns the default value of the column as binary string.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-
-```
-class InformationSchema\Table\VarbinaryColumn extends Column
 {
     /**
      * Returns the maximum length in bytes.
@@ -605,59 +448,6 @@ class InformationSchema\Table\BlobColumn extends Column
     public function getDefaultValue(): ?string {}
 }
 ```
-
-##### Enum types
-
-```
-class InformationSchema\Table\EnumColumn extends Column
-{
-    /**
-     * Returns the values defined by the enumeration.
-     */
-    public function getEnumValues(): array {}
-
-    /**
-     * Returns the default value of the column as binary string.
-     *
-     * @return string|null
-     */
-    public function getDefaultValue(): ?string {}
-}
-```
-Note that this is not an ANSI-SQL datatype but can be achieved in most RDBMS. MySQL / MariaDB do support this at column
-creation time:
-```
-CREATE TABLE myTest (
-    myEnum enum('foo', 'bar', 'baz')
-);
-```
-In PostgreSQL the same can be accomplished by creating a type: 
-```
-CREATE TYPE myEnumType AS enum ('foo', 'bar', 'baz');
-CREATE TABLE myTest (
-    myEnum myEnumType
-);
-```
-In case an RDBMS neither has support for `enum` data types nor allows to create custom types, the same can be 
-accomplished by introducing a check constraint:
-```
-CREATE TABLE myTest (
-    myEnum VARCHAR(10) CHECK (myEnum IN ('foo', 'bar', 'baz'))
-);
-``` 
-
-##### Collection types
-
-SQL2003 defines the type `array` and `multiset` which are rarely used and not supported by many RDBMS. Since there are 
-other means to store such data (e.g. serialized, relational) no classes for these types are provided.
-
-##### RDBMS specific types
-
-Every RDMBS comes with their custom set of data types that are not standard. While MySQL and PostgreSQL allow to store 
-spatial (aka geometric) types, this is not common with Oracle or MSSQL (although both allow to define custom types and
-could be made to store such types).
-
-Such RDBMS specific types need not be taken into account at the time being.
 
 #### Providers
 

--- a/design-documents/database/declarative-schema-database-compatibility.md
+++ b/design-documents/database/declarative-schema-database-compatibility.md
@@ -76,9 +76,9 @@ class InformationSchema\Table
      *
      * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
      *
-     * @return string|null
+     * @return EngineEnum
      */
-    public function getEngine(): ?string;
+    public function getEngine(): EngineEnum;
 
     /**
      * Returns the comment used when creating the table.
@@ -110,6 +110,19 @@ class InformationSchema\Table
 ```
 Note: `AUTO_INCREMENT` is omitted intentionally. Auto increment must not be used for the application logic.
 
+```
+class InformationSchema\EngineEnum extends \SplEnum
+{
+    const __default = self::TRANSACTIONAL;
+
+    const IN_MEMORY = 'in memory'
+    const NON_TRANSACTIONAL = 'non tranactional';
+    const TRANSACTIONAL = 'transactional'
+}
+```
+Note: `SplEnum` is part of the SPLTypes PECL package, it might not be available on all systems, thus we may have to 
+create a userland enum class!
+
 #### Columns
 
 ```
@@ -127,15 +140,6 @@ class InformationSchema\Extra
 ```
 abstract class InformationSchema\Table\Column
 {
-    /**
-     * Defines the ANSI-SQL column type that is reflected by current class.
-     *
-     * Note that this does not neccessarily reflect the data type name of all RDBMS (e.g. PostgreSQL uses `text` instead
-     * of `CLOB`).
-     * Thus the value stored herein should be used to map ANSI-SQL data types to RDBMS specific datatypes. 
-     */
-    public const TYPE = '';
-
     /**
      * Retuns the name of the table to which colum belongs.
      *
@@ -189,8 +193,6 @@ abstract class InformationSchema\Table\Column
 ```
 class InformationSchema\Table\BoolColumn extends Column
 {
-    public const TYPE = 'BOOLEAN';
-
     /**
      * Returns the default value of the column.
      *
@@ -204,77 +206,8 @@ Note that MySQL / MariaDB maps this type to `tinyint(1)` thus resulting in an in
 ##### Numeric types
 
 ```
-class InformationSchema\Table\BitColumn extends Column
-{
-    public const TYPE = 'BIT';
-
-    /**
-     * Returns the amount of bits the column can store.
-     *
-     * @return int
-     */
-    public function getBitLength(): int {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return int|null
-     */
-    public function getDefaultValue(): ?int {}
-}
-```
-
-```
-class InformationSchema\Table\VarBitColumn extends Column
-{
-    public const TYPE = 'BIT VARYING';
-
-    /**
-     * Returns the amount of bits the column can store.
-     *
-     * @return int
-     */
-    public function getBitLength(): int {}
-
-    /**
-     * Returns the default value of the column.
-     *
-     * @return int|null
-     */
-    public function getDefaultValue(): ?int {}
-}
-```
-
-```
 class InformationSchema\Table\IntColumn extends Column
 {
-    public const TYPE = 'INTEGER';
-
-    /**
-     * Returns whether the column contains signed or unsigned integers.
-     *
-     * Note that not all RDBMS support this, thus `false` should be returned for RDBMS that do not support this.
-     *
-     * @return bool
-     */
-    public function isUnsigned(): bool {}
-
-    /**
-     * Returns the (left) padding for the integer.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return int
-     */
-    public function getPadding(): ?int {}
-
-    /**
-     * Returns the precision (amount of digits) the column can store.
-     *
-     * @return int
-     */
-    public function getPrecision(): int {}
-
     /**
      * Returns the default value of the column.
      *
@@ -287,33 +220,6 @@ class InformationSchema\Table\IntColumn extends Column
 ```
 class InformationSchema\Table\SmallIntColumn extends Column
 {
-    public const TYPE = 'SMALLINT';
-
-    /**
-     * Returns whether the column contains signed or unsigned integers.
-     *
-     * Note that not all RDBMS support this, thus `false` should be returned for RDBMS that do not support this.
-     *
-     * @return bool
-     */
-    public function isUnsigned(): bool {}
-
-    /**
-     * Returns the (left) padding for the integer.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return int
-     */
-    public function getPadding(): ?int {}
-
-    /**
-     * Returns the precision (amount of digits) the column can store.
-     *
-     * @return int
-     */
-    public function getPrecision(): int {}
-
     /**
      * Returns the default value of the column.
      *
@@ -326,33 +232,6 @@ class InformationSchema\Table\SmallIntColumn extends Column
 ```
 class InformationSchema\Table\BigIntColumn extends Column
 {
-    public const TYPE = 'BIGINT';
-
-    /**
-     * Returns whether the column contains signed or unsigned integers.
-     *
-     * Note that not all RDBMS support this, thus `false` should be returned for RDBMS that do not support this.
-     *
-     * @return bool
-     */
-    public function isUnsigned(): bool {}
-
-    /**
-     * Returns the (left) padding for the integer.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return int
-     */
-    public function getPadding(): ?int {}
-
-    /**
-     * Returns the precision (amount of digits) the column can store.
-     *
-     * @return int
-     */
-    public function getPrecision(): int {}
-
     /**
      * Returns the default value of the column.
      *
@@ -365,8 +244,6 @@ class InformationSchema\Table\BigIntColumn extends Column
 ```
 class InformationSchema\Table\DecimalColumn extends Column
 {
-    public const TYPE = 'DECIMAL';
-
     /**
      * Returns the precision (amount of digits) the column can store.
      *
@@ -398,23 +275,12 @@ to `NUMERIC`. This needs to be kept in mind should support for other RDBMS becom
 ```
 class InformationSchema\Table\RealColumn extends Column
 {
-    public const TYPE = 'REAL';
-
     /**
      * Returns the precision (amount of digits) the column can store.
      *
      * @return int
      */
     public function getPrecision(): int {}
-
-    /**
-     * Returns the scale (amount of digits right of the decimal point) the column can store.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return int|null
-     */
-    public function getScale(): ?int {}
 
     /**
      * Returns the default value of the column.
@@ -430,23 +296,12 @@ by setting the [REAL_AS_FLOAT](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.
 ```
 class InformationSchema\Table\DoublePrecisionColumn extends Column
 {
-    public const TYPE = 'DOUBLE PRECISION';
-
     /**
      * Returns the precision (amount of digits) the column can store.
      *
      * @return int
      */
     public function getPrecision(): int {}
-
-    /**
-     * Returns the scale (amount of digits right of the decimal point) the column can store.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return int|null
-     */
-    public function getScale(): ?int {}
 
     /**
      * Returns the default value of the column.
@@ -460,23 +315,12 @@ class InformationSchema\Table\DoublePrecisionColumn extends Column
 ```
 class InformationSchema\Table\FloatColumn extends Column
 {
-    public const TYPE = 'FLOAT';
-
     /**
      * Returns the precision (amount of digits) the column can store.
      *
      * @return int
      */
     public function getPrecision(): int {}
-
-    /**
-     * Returns the scale (amount of digits right of the decimal point) the column can store.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return int|null
-     */
-    public function getScale(): ?int {}
 
     /**
      * Returns the default value of the column.
@@ -492,30 +336,10 @@ class InformationSchema\Table\FloatColumn extends Column
 ```
 class InformationSchema\Table\CharColumn extends Column
 {
-    public const TYPE = 'CHARACTER';
-
     /**
      * Retturns the maximum length in characters.
      */
     public function getCharLength(): int {}
-
-    /**
-     * Returns the character set name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCharsetName(): ?string {}
-
-    /**
-     * Returns the collation name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCollationName(): ?string {}
 
     /**
      * Returns the default value of the column.
@@ -528,30 +352,10 @@ class InformationSchema\Table\CharColumn extends Column
 ```
 class InformationSchema\Table\NationalCharColumn extends Column
 {
-    public const TYPE = 'NATIONAL CHARACTER';
-
     /**
      * Retturns the maximum length in characters.
      */
     public function getCharLength(): int {}
-
-    /**
-     * Returns the character set name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCharsetName(): ?string {}
-
-    /**
-     * Returns the collation name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCollationName(): ?string {}
 
     /**
      * Returns the default value of the column.
@@ -566,32 +370,12 @@ Note that MySQL / MariaDB maps this type to `char`.
 ```
 class InformationSchema\Table\VarcharColumn extends Column
 {
-    public const TYPE = 'VARCHAR';
-
     /**
      * Returns the maximum length in characters.
      *
      * @return int
      */
     public function getCharLength(): int {}
-
-    /**
-     * Returns the character set name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCharsetName(): ?string {}
-
-    /**
-     * Returns the collation name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCollationName(): ?string {}
 
     /**
      * Returns the default value of the column.
@@ -605,32 +389,12 @@ class InformationSchema\Table\VarcharColumn extends Column
 ```
 class InformationSchema\Table\NationalVarcharColumn extends Column
 {
-    public const TYPE = 'NATIONAL VARCHAR';
-
     /**
      * Returns the maximum length in characters.
      *
      * @return int
      */
     public function getCharLength(): int {}
-
-    /**
-     * Returns the character set name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCharsetName(): ?string {}
-
-    /**
-     * Returns the collation name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCollationName(): ?string {}
 
     /**
      * Returns the default value of the column.
@@ -645,26 +409,6 @@ Note that MySQL / MariaDB maps this type to `varchar`.
 ```
 class InformationSchema\Table\ClobColumn extends Column
 {
-    public const TYPE = 'CLOB';
-
-    /**
-     * Returns the character set name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCharsetName(): ?string {}
-
-    /**
-     * Returns the collation name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCollationName(): ?string {}
-
     /**
      * Returns the default value of the column.
      *
@@ -678,26 +422,6 @@ Note that MySQL / MariaDB and PostgreSQL use the type `text` for this purpose.
 ```
 class InformationSchema\Table\NationalClobColumn extends Column
 {
-    public const TYPE = 'NCLOB';
-
-    /**
-     * Returns the character set name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCharsetName(): ?string {}
-
-    /**
-     * Returns the collation name.
-     *
-     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
-     *
-     * @return string|null
-     */
-    public function getCollationName(): ?string {}
-
     /**
      * Returns the default value of the column.
      *
@@ -713,8 +437,6 @@ Note that MySQL / MariaDB does not have support for a national type of character
 ```
 class InformationSchema\Table\DateColumn extends Column
 {
-    public const TYPE = 'DATE';
-
     /**
      * Returns the default value of the column.
      *
@@ -727,8 +449,6 @@ class InformationSchema\Table\DateColumn extends Column
 ```
 class InformationSchema\Table\TimeColumn extends Column
 {
-    public const TYPE = 'TIME';
-
     /**
      * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
      * value).
@@ -749,8 +469,6 @@ class InformationSchema\Table\TimeColumn extends Column
 ```
 class InformationSchema\Table\TimeWithTimezoneColumn extends Column
 {
-    public const TYPE = 'TIME WITH TIMEZONE';
-
     /**
      * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
      * value).
@@ -771,8 +489,6 @@ class InformationSchema\Table\TimeWithTimezoneColumn extends Column
 ```
 class InformationSchema\Table\TimestampColumn extends Column
 {
-    public const TYPE = 'TIMESTAMP';
-
     /**
      * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
      * value).
@@ -793,8 +509,6 @@ class InformationSchema\Table\TimestampColumn extends Column
 ```
 class InformationSchema\Table\TimestampWithTimezoneColumn extends Column
 {
-    public const TYPE = 'TIMESTAMP WITH TIMEZONE';
-
     /**
      * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
      * value).
@@ -815,8 +529,6 @@ class InformationSchema\Table\TimestampWithTimezoneColumn extends Column
 ```
 class InformationSchema\Table\IntervalColumn extends Column
 {
-    public const TYPE = 'INTERVAL';
-
     /**
      * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
      * value).
@@ -847,8 +559,6 @@ equivalent to `interval MONTH`).
 ```
 class InformationSchema\Table\BinaryColumn extends Column
 {
-    public const TYPE = 'BINARY';
-
     /**
      * Returns the maximum length in bytes.
      *
@@ -868,8 +578,6 @@ class InformationSchema\Table\BinaryColumn extends Column
 ```
 class InformationSchema\Table\VarbinaryColumn extends Column
 {
-    public const TYPE = 'VARBINARY';
-
     /**
      * Returns the maximum length in bytes.
      *
@@ -889,8 +597,6 @@ class InformationSchema\Table\VarbinaryColumn extends Column
 ```
 class InformationSchema\Table\BlobColumn extends Column
 {
-    public const TYPE = 'BLOB';
-
     /**
      * Returns the default value of the column as binary string.
      *
@@ -905,8 +611,6 @@ class InformationSchema\Table\BlobColumn extends Column
 ```
 class InformationSchema\Table\EnumColumn extends Column
 {
-    public const TYPE = 'ENUM';
-
     /**
      * Returns the values defined by the enumeration.
      */
@@ -956,6 +660,9 @@ could be made to store such types).
 Such RDBMS specific types need not be taken into account at the time being.
 
 #### Providers
+
+Providers are responsible for mapping RDBMS specific types to the ANSI-SQL column types (e.g. `text` in MySQL is mapped 
+to `InformationSchema\Table\ClobColumn`). 
 
 ```
 interface InformationSchema\Table\ColumnProviderInterface

--- a/design-documents/database/declarative-schema-database-compatibility.md
+++ b/design-documents/database/declarative-schema-database-compatibility.md
@@ -29,65 +29,431 @@ For `COLUMN_DEFAULT`, PHP PDO connector returns `NULL` for MySQL and `"NULL"` (s
 
 ## Design
 
-Introduce new interfaces under Db namespace that would allow to get information about table schema, refactor implementations of `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface` in declarative schema to use interfaces under Db namespace.
+Introduce new interfaces under Db namespace that would allow to get information about table schema, refactor 
+implementations of `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface` in declarative schema to use 
+interfaces under Db namespace.
 
 Revise implementation of these interfaces to see if anything need to be changed here
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
 
-New interfaces and types for managing table schema.
+### New interfaces and types for managing table schema.
+
+Designing a database abstraction layer is no easy task as one has to have a vast knowledge on various RDBMS and their
+interpretation of ANSI-SQL. Especially when it comes to metadata most common RDBMS used in web projects do make use of 
+the `information_schema`, yet some big players (e.g. Oracle) do not implement this feature. Since metadata is closely 
+coupled with supported data types, one also faces the problem that not all data types defined by ANSI-SQL are supported
+by all RDMBS or have very special implementations for the latter, e.g. MySQL / MariaDB does not have a distinct `boolean`
+data type but rather map it to `tinyint(1)` which is not the same since it stores values from `0` to `9` (as opposed to
+`true` and `false` for an actual `boolean`) but behaves similarly.
+
+Taking into account that Magento makes use of the Zend Framework, I strongly suggest to make use of 
+`\Zend\Db\Metadata\MetadataInterface` instead of trying to reinvent the wheel.
+
+Nevertheless, here is a potential draft for implementing a metadata engine.
+
+#### Tables
 
 ```
 class InformationSchema\Table
 {
-    public function getSchema(): string {}
-    public function getName(): string {}
-    public function getEngine(): string {}
-    public function getComment(): string {}
-    public function getCollation(): string {}
-    public function getCharset(): string {}
+    /**
+     * Returns The name of the schema (database) to which the table belongs.
+     *
+     * @return string 
+     */
+    public function getSchema(): string;
+
+    /**
+     * Returns the name of the table.
+     *
+     * @return string 
+     */
+    public function getName(): string;
+
+    /**
+     * Returns the storage engine for the table.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getEngine(): ?string;
+
+    /**
+     * Returns the comment used when creating the table.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getComment(): ?string;
+
+    /**
+     * Returns the table's default collation.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported. 
+     *
+     * @return string|null
+     */
+    public function getCollation(): ?string;
+
+    /**
+     * Returns the table's default character set.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharset(): ?string;
 }
 ```
-Note: auto increment is omitted intentionally. Auto increment should not be used for the application logic.
+Note: `AUTO_INCREMENT` is omitted intentionally. Auto increment must not be used for the application logic.
+
+#### Columns
 
 ```
 class InformationSchema\Extra
 {
-    public function getOnUpdate(): string {}
+    /**
+     * Returns the on-update clause of a column.
+     *
+     * @return string|null
+     */
+    public function getOnUpdate(): ?string {}
 }
 ```
 
 ```
 abstract class InformationSchema\Table\Column
 {
+    /**
+     * Defines the ANSI-SQL column type that is reflected by current class.
+     *
+     * Note that this does not neccessarily reflect the data type name of all RDBMS (e.g. PostgreSQL uses `text` instead
+     * of `CLOB`).
+     * Thus the value stored herein should be used to map ANSI-SQL data types to RDBMS specific datatypes. 
+     */
+    public const TYPE = '';
+
+    /**
+     * Retuns the name of the table to which colum belongs.
+     *
+     * @return string
+     */
     public function getTableName(): string {}
+
+    /**
+     * Returns the name of the column.
+     *
+     * @return string
+     */
     public function getName(): string {}
+
+    /**
+     * Returns whether column is nullable.
+     *
+     * @return bool
+     */
     public function getIsNullable(): bool {}
-    public function getExtra(): Extra {}
-    public function getComment() {}
-    public function getDefaultValue(): ?string {}
+
+    /**
+     * Returns the data object for the extra information of a column.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return ColumnExtraInterface|null
+     */
+    public function getExtra(): ?ColumnExtraInterface {}
+
+    /**
+     * Returns the comment included in the column definition.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getComment(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return mixed
+     */
+    public function getDefaultValue() {}
+}
+```
+
+##### Boolean types
+
+```
+class InformationSchema\Table\BoolColumn extends Column
+{
+    public const TYPE = 'BOOLEAN';
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return int|null
+     */
+    public function getDefaultValue(): ?int {}
+}
+```
+Note that MySQL / MariaDB maps this type to `tinyint(1)` thus resulting in an integer type.
+
+##### Numeric types
+
+```
+class InformationSchema\Table\BitColumn extends Column
+{
+    public const TYPE = 'BIT';
+
+    /**
+     * Returns the amount of bits the column can store.
+     *
+     * @return int
+     */
+    public function getBitLength(): int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return int|null
+     */
+    public function getDefaultValue(): ?int {}
 }
 ```
 
 ```
-class InformationSchema\Table\VarcharColumn extends Column
+class InformationSchema\Table\VarBitColumn extends Column
 {
-    public const TYPE = 'VARCHAR';
+    public const TYPE = 'BIT VARYING';
 
-    public function getCharLength(): int {}
-    public function getCharsetName(): string {}
-    public function getCollationName(): string {}
+    /**
+     * Returns the amount of bits the column can store.
+     *
+     * @return int
+     */
+    public function getBitLength(): int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return int|null
+     */
+    public function getDefaultValue(): ?int {}
 }
 ```
 
 ```
 class InformationSchema\Table\IntColumn extends Column
 {
-    public const TYPE = 'INT';
+    public const TYPE = 'INTEGER';
 
+    /**
+     * Returns whether the column contains signed or unsigned integers.
+     *
+     * Note that not all RDBMS support this, thus `false` should be returned for RDBMS that do not support this.
+     *
+     * @return bool
+     */
     public function isUnsigned(): bool {}
-    public function getPadding(): int {}
-    public function getType(): IntEnum {}
+
+    /**
+     * Returns the (left) padding for the integer.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return int
+     */
+    public function getPadding(): ?int {}
+
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
+    public function getPrecision(): int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return int|null
+     */
+    public function getDefaultValue(): ?int {}
+}
+```
+
+```
+class InformationSchema\Table\SmallIntColumn extends Column
+{
+    public const TYPE = 'SMALLINT';
+
+    /**
+     * Returns whether the column contains signed or unsigned integers.
+     *
+     * Note that not all RDBMS support this, thus `false` should be returned for RDBMS that do not support this.
+     *
+     * @return bool
+     */
+    public function isUnsigned(): bool {}
+
+    /**
+     * Returns the (left) padding for the integer.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return int
+     */
+    public function getPadding(): ?int {}
+
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
+    public function getPrecision(): int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return int|null
+     */
+    public function getDefaultValue(): ?int {}
+}
+```
+
+```
+class InformationSchema\Table\BigIntColumn extends Column
+{
+    public const TYPE = 'BIGINT';
+
+    /**
+     * Returns whether the column contains signed or unsigned integers.
+     *
+     * Note that not all RDBMS support this, thus `false` should be returned for RDBMS that do not support this.
+     *
+     * @return bool
+     */
+    public function isUnsigned(): bool {}
+
+    /**
+     * Returns the (left) padding for the integer.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return int
+     */
+    public function getPadding(): ?int {}
+
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
+    public function getPrecision(): int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return int|null
+     */
+    public function getDefaultValue(): ?int {}
+}
+```
+
+```
+class InformationSchema\Table\DecimalColumn extends Column
+{
+    public const TYPE = 'DECIMAL';
+
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
+    public function getPrecision(): int {}
+
+    /**
+     * Returns the scale (amount of digits right of the decimal point) the column can store.
+     *
+     * In case the column has not been defined to have a numeric scale (aka dynamic scale), `null` is returned.
+     *
+     * @return int|null
+     */
+    public function getScale(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return float|null
+     */
+    public function getDefaultValue(): ?float {}
+}
+```
+Note that ANSI-SQL defines the exact numerical data types `DECIMAL` and `NUMERIC` as being equivalent. MySQL / MariaDB
+sticks to this definitions and maps `NUMERIC` to `DECIMAL`. PostgreSQL behaves the other way around, mapping `DECIMAL`
+to `NUMERIC`. This needs to be kept in mind should support for other RDBMS become a thing in Magento.
+
+```
+class InformationSchema\Table\RealColumn extends Column
+{
+    public const TYPE = 'REAL';
+
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
+    public function getPrecision(): int {}
+
+    /**
+     * Returns the scale (amount of digits right of the decimal point) the column can store.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return int|null
+     */
+    public function getScale(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return float|null
+     */
+    public function getDefaultValue(): ?float {}
+}
+```
+Note that by default MySQL / MariaDB treats `REAL` as an alias for `DOUBLE PRECISION`. This behaviour can be changed 
+by setting the [REAL_AS_FLOAT](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_real_as_float) mode.
+
+```
+class InformationSchema\Table\DoublePrecisionColumn extends Column
+{
+    public const TYPE = 'DOUBLE PRECISION';
+
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
+    public function getPrecision(): int {}
+
+    /**
+     * Returns the scale (amount of digits right of the decimal point) the column can store.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return int|null
+     */
+    public function getScale(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return float|null
+     */
+    public function getDefaultValue(): ?float {}
 }
 ```
 
@@ -96,22 +462,500 @@ class InformationSchema\Table\FloatColumn extends Column
 {
     public const TYPE = 'FLOAT';
 
-    public function getDefaultValue() {}
-    public function getScale(): int {}
+    /**
+     * Returns the precision (amount of digits) the column can store.
+     *
+     * @return int
+     */
     public function getPrecision(): int {}
-    public function getNumericScale(): int {}
+
+    /**
+     * Returns the scale (amount of digits right of the decimal point) the column can store.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return int|null
+     */
+    public function getScale(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return float|null
+     */
+    public function getDefaultValue(): ?float {}
 }
 ```
+
+##### String types
+
+```
+class InformationSchema\Table\CharColumn extends Column
+{
+    public const TYPE = 'CHARACTER';
+
+    /**
+     * Retturns the maximum length in characters.
+     */
+    public function getCharLength(): int {}
+
+    /**
+     * Returns the character set name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharsetName(): ?string {}
+
+    /**
+     * Returns the collation name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCollationName(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+```
+class InformationSchema\Table\NationalCharColumn extends Column
+{
+    public const TYPE = 'NATIONAL CHARACTER';
+
+    /**
+     * Retturns the maximum length in characters.
+     */
+    public function getCharLength(): int {}
+
+    /**
+     * Returns the character set name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharsetName(): ?string {}
+
+    /**
+     * Returns the collation name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCollationName(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+Note that MySQL / MariaDB maps this type to `char`.
+
+```
+class InformationSchema\Table\VarcharColumn extends Column
+{
+    public const TYPE = 'VARCHAR';
+
+    /**
+     * Returns the maximum length in characters.
+     *
+     * @return int
+     */
+    public function getCharLength(): int {}
+
+    /**
+     * Returns the character set name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharsetName(): ?string {}
+
+    /**
+     * Returns the collation name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCollationName(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\NationalVarcharColumn extends Column
+{
+    public const TYPE = 'NATIONAL VARCHAR';
+
+    /**
+     * Returns the maximum length in characters.
+     *
+     * @return int
+     */
+    public function getCharLength(): int {}
+
+    /**
+     * Returns the character set name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharsetName(): ?string {}
+
+    /**
+     * Returns the collation name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCollationName(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+Note that MySQL / MariaDB maps this type to `varchar`.
+
+```
+class InformationSchema\Table\ClobColumn extends Column
+{
+    public const TYPE = 'CLOB';
+
+    /**
+     * Returns the character set name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharsetName(): ?string {}
+
+    /**
+     * Returns the collation name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCollationName(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+Note that MySQL / MariaDB and PostgreSQL use the type `text` for this purpose.
+
+```
+class InformationSchema\Table\NationalClobColumn extends Column
+{
+    public const TYPE = 'NCLOB';
+
+    /**
+     * Returns the character set name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCharsetName(): ?string {}
+
+    /**
+     * Returns the collation name.
+     *
+     * Note that not all RDBMS support this, returning `null` indicates whether this is supported.
+     *
+     * @return string|null
+     */
+    public function getCollationName(): ?string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+Note that MySQL / MariaDB does not have support for a national type of character large object.
+
+##### Date/Time types
 
 ```
 class InformationSchema\Table\DateColumn extends Column
 {
     public const TYPE = 'DATE';
 
-    public function getDefaultValue(): string {}
-    public function getDatetimePrecision(): int {}
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
 }
 ```
+
+```
+class InformationSchema\Table\TimeColumn extends Column
+{
+    public const TYPE = 'TIME';
+
+    /**
+     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
+     * value).
+     *
+     * @return int|null 
+     */
+    public function getPrecision(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\TimeWithTimezoneColumn extends Column
+{
+    public const TYPE = 'TIME WITH TIMEZONE';
+
+    /**
+     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
+     * value).
+     *
+     * @return int|null 
+     */
+    public function getPrecision(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\TimestampColumn extends Column
+{
+    public const TYPE = 'TIMESTAMP';
+
+    /**
+     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
+     * value).
+     *
+     * @return int|null 
+     */
+    public function getPrecision(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\TimestampWithTimezoneColumn extends Column
+{
+    public const TYPE = 'TIMESTAMP WITH TIMEZONE';
+
+    /**
+     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
+     * value).
+     *
+     * @return int|null 
+     */
+    public function getPrecision(): ?int {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\IntervalColumn extends Column
+{
+    public const TYPE = 'INTERVAL';
+
+    /**
+     * Returns the fractional seconds precision (the amount of digits maitained after the decimal dot of the seconds 
+     * value).
+     *
+     * @return int|null 
+     */
+    public function getPrecision(): ?int {}
+
+    /**
+     * Returns the timestamp fields that are stored by interval.
+     */
+    public function getIntervalFields(): string {}
+
+    /**
+     * Returns the default value of the column.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+Note that MySQL / MariaDB does not support the `interval` type but rather suggests to use the `time` type which is 
+limited compared to `interval` as it can only store the range '-838:59:59.000000' to '838:59:59.000000' (roughly 
+equivalent to `interval MONTH`).
+
+##### Binary types
+
+```
+class InformationSchema\Table\BinaryColumn extends Column
+{
+    public const TYPE = 'BINARY';
+
+    /**
+     * Returns the maximum length in bytes.
+     *
+     * @return int
+     */
+    public function getByteLength(): int {}
+
+    /**
+     * Returns the default value of the column as binary string.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\VarbinaryColumn extends Column
+{
+    public const TYPE = 'VARBINARY';
+
+    /**
+     * Returns the maximum length in bytes.
+     *
+     * @return int
+     */
+    public function getByteLength(): int {}
+
+    /**
+     * Returns the default value of the column as binary string.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+```
+class InformationSchema\Table\BlobColumn extends Column
+{
+    public const TYPE = 'BLOB';
+
+    /**
+     * Returns the default value of the column as binary string.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+
+##### Enum types
+
+```
+class InformationSchema\Table\EnumColumn extends Column
+{
+    public const TYPE = 'ENUM';
+
+    /**
+     * Returns the values defined by the enumeration.
+     */
+    public function getEnumValues(): array {}
+
+    /**
+     * Returns the default value of the column as binary string.
+     *
+     * @return string|null
+     */
+    public function getDefaultValue(): ?string {}
+}
+```
+Note that this is not an ANSI-SQL datatype but can be achieved in most RDBMS. MySQL / MariaDB do support this at column
+creation time:
+```
+CREATE TABLE myTest (
+    myEnum enum('foo', 'bar', 'baz')
+);
+```
+In PostgreSQL the same can be accomplished by creating a type: 
+```
+CREATE TYPE myEnumType AS enum ('foo', 'bar', 'baz');
+CREATE TABLE myTest (
+    myEnum myEnumType
+);
+```
+In case an RDBMS neither has support for `enum` data types nor allows to create custom types, the same can be 
+accomplished by introducing a check constraint:
+```
+CREATE TABLE myTest (
+    myEnum VARCHAR(10) CHECK (myEnum IN ('foo', 'bar', 'baz'))
+);
+``` 
+
+##### Collection types
+
+SQL2003 defines the type `array` and `multiset` which are rarely used and not supported by many RDBMS. Since there are 
+other means to store such data (e.g. serialized, relational) no classes for these types are provided.
+
+##### RDBMS specific types
+
+Every RDMBS comes with their custom set of data types that are not standard. While MySQL and PostgreSQL allow to store 
+spatial (aka geometric) types, this is not common with Oracle or MSSQL (although both allow to define custom types and
+could be made to store such types).
+
+Such RDBMS specific types need not be taken into account at the time being.
+
+#### Providers
 
 ```
 interface InformationSchema\Table\ColumnProviderInterface
@@ -119,22 +963,50 @@ interface InformationSchema\Table\ColumnProviderInterface
     /**
      * @return Column[]
      */
-    public function getColumns(string $tableName, string $connectionName);
+    public function getColumns(string $tableName): array;
 }
 ```
 
-// Consider removing $connectionName from the interface (move to constructor via resolver that returns by table name)
 ```
 interface InformationSchema\TableProviderInterface
 {
-    public function getTableByName(string $tableName, string $connectionName): Table;
-    public function getAllTables(string $connectionName): Table; // check if we use it anywhere
+    public function getTableByName(string $tableName): Table;
+}
+```
+
+```
+use Magento\Framework\DB\Adapter\AdapterInterface;
+
+class InformationSchema\ConnectionResolver
+{
+    public function getConnectionForTable(string $tableName): AdapterInterface {}
+}
+```
+
+```
+abstract class InformationSchema\AbstractTableProvider implements TableProviderInterface
+{
+    public function __construct(ConnectionResolver $connectionResolver)
+    {
+        $this->connectionResolver = $connectionResolver;
+    }
+}
+```
+
+```
+abstract class InformationSchema\AbstractColumnProvider implements ColumnProviderInterface
+{
+    public function __construct(ConnectionResolver $connectionResolver)
+    {
+        $this->connectionResolver = $connectionResolver;
+    }
 }
 ```
 
 ### Profiles
 
-The above interfaces will have multiple implementations, and the framework should be switching between them depending on the RDBMS it works with.
+The above interfaces will have multiple implementations, and the framework should be switching between them depending on
+the RDBMS it works with.
 The framework decides which implementations to use based on declared profiles.
 The profiles are declared in `di.xml` or as a separate configuration, with the following structure:
 
@@ -165,43 +1037,57 @@ This is repeated for each connection.
 
 The profile is recorded in `env.php` as part of installation/upgrade process.
 
-A user (SI) also can specify the profile manually. This can be helpful in case a custom distributive of RDBMS is used and Magento application can't identify correctly which profile to use.
+A user (SI) also can specify the profile manually. This can be helpful in case a custom distributive of RDBMS is used 
+and Magento application can't identify correctly which profile to use.
 The following tools should provide an ability for the user to specify the profile:
 
 * CLI installation command
 * Web installation UI
 * CLI command to update the profile (or manually update `env.php`)
 
-When Magento application is running and needs to read DB Information Schema, necessary implementation is selected based on the profile in `env.php`.
+When Magento application is running and needs to read DB Information Schema, necessary implementation is selected based 
+on the profile in `env.php`.
 
 ### Alternative approach
 
 Alternative approach is to reuse existing interfaces and add replaceability on the level of declarative schema.
 
-`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept 
+`\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific 
+implementations of `DbSchemaReaderInterface` for given connection. 
+`\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on 
+`\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database 
+adapter.
 
-Similar approach need to be taken for clients of the following interfaces
+Similar approach needs to be taken for clients of the following interfaces
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
 
 ### Replaceability of `\Magento\Framework\DB\Adapter\AdapterInterface`
 
-Not needed for declarative schema, but with this refactoring would also make sense to add ability to have different adapters for different databases.
+Not needed for declarative schema, but with this refactoring would also make sense to add ability to have different 
+adapters for different databases.
 
-`\Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface` currently returns instance of `Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface` that is defined by preference, similarly to approach above it should resolve database specific adapter based on configuration.
+`\Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface` currently returns instance of 
+`Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface` that is defined by preference, similarly to 
+approach above it should resolve database specific adapter based on configuration.
 
-`model` is the name of parameter that supposed to be used to configure database specific adapters. Somehow functionality behind it is absent.
+`model` is the name of the parameter that is supposed to be used to configure database specific adapters. Somehow 
+functionality behind it is absent.
 
-It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariadb` and have `mysql4` be alias for `mysql`.
+It has te default value of `mysql4`. I propose to add 2 values: `mysql` and `mariadb` and have `mysql4` be an alias for 
+`mysql`.
 
 ## Considerations
 
-`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.
+`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database 
+engine. This is a leaky interface. We should have interfaces that return normalized data and are compatible with all 
+databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.
 
 ## Resources
 
 * https://en.wikipedia.org/wiki/Information_schema
 * [MariaDB Information Schema COLUMNS](https://mariadb.com/kb/en/library/information-schema-columns-table/)
 * [MySQL Information Schema COLUMNS](https://dev.mysql.com/doc/refman/5.7/en/columns-table.html)
-* [MDEV-13132](https://jira.mariadb.org/browse/MDEV-13132) - ticket in MariaDB issue tracker, where they changes behavior of `COLUMN_DEFAULT`
+* [MDEV-13132](https://jira.mariadb.org/browse/MDEV-13132) - ticket in MariaDB issue tracker, where they changed behavior of `COLUMN_DEFAULT`

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -1,0 +1,45 @@
+# Declarative schema database compatibility
+
+## About
+
+Declarative schema relies on querying data that may have different format depending on database. For example, here is the query from `Magento\Framework\Setup\Declaration\Schema\Db\MySQL\DbSchemaReader::readColumns`
+
+```
+SELECT 
+	COLUMN_NAME as 'name',
+	COLUMN_DEFAULT as 'default',
+	DATA_TYPE as 'type',
+	IS_NULLABLE as 'nullable',
+	COLUMN_TYPE as 'definition',
+	EXTRA as 'extra',
+	COLUMN_COMMENT as 'comment'
+FROM
+    information_schema.COLUMNS
+WHERE
+    TABLE_SCHEMA = 'magento'
+AND
+    TABLE_NAME = 'store_website'
+ORDER BY
+    ORDINAL_POSITION ASC;
+```
+
+MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
+
+## Design
+
+Introduce concept of database adapters to allow normalize values in declarative schema for different databases.
+
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Schema\Db\MySQL\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Schema\Db\MySQL\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+
+Similar approach need to be taken for clients of the following interfaces
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface`
+
+Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
+
+`\Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface` currently returns instance of `Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface` that is defined by preference, similarly to approach above it should resolve database specific adapter based on configuration.
+
+`model` is the name of parameter that supposed to be used to configure database specific adapters. Somehow functionality behind it is absent.
+
+It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariadb` and have `mysql4` be alias for `mysql`.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -43,3 +43,7 @@ Not needed for declarative schema, but with this refactoring would also make sen
 `model` is the name of parameter that supposed to be used to configure database specific adapters. Somehow functionality behind it is absent.
 
 It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariadb` and have `mysql4` be alias for `mysql`.
+
+## Considerations
+
+`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. Ideally we should have an interface that would return normalized data and be compatible with all databases. This is a much larger change and might be considered for minor release.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -29,7 +29,7 @@ MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
 
 Introduce concept of database adapters to allow normalize values in declarative schema for different databases.
 
-`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Schema\Db\MySQL\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Schema\Db\MySQL\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
 
 Similar approach need to be taken for clients of the following interfaces
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -50,8 +50,6 @@ class InformationSchema\Table
 ```
 Note: auto increment is omitted intentionally. Auto increment should not be used for the application logic.
 
-Those classes duplicate already existing ones in `lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns`
-
 ```
 class InformationSchema\Extra
 {
@@ -64,23 +62,29 @@ abstract class InformationSchema\Table\Column
 {
     public function getTableName(): string {}
     public function getName(): string {}
-    public function getType(): string {}
     public function getIsNullable(): bool {}
     public function getExtra(): Extra {}
     public function getComment() {}
     public function getDefaultValue(): string {}
-    public function getCharLength(): ?int {} // for string only
-    public function getCharsetName(): string {} // for string only
-    public function getCollationName(): string {} // for string only
-    public function getPrecision(): ?int {} // for int/dec only
-    public function getNumericScale(): ?int {} // for int/dec only
-    public function getDatetimePrecision(): ?int {} // for temporal only
 }
 ```
 
 ```
-class InformationSchema\Table\IntegerColumn extends Column
+class InformationSchema\Table\VarcharColumn extends Column
 {
+    public const TYPE = 'VARCHAR';
+
+    public function getCharLength(): int {}
+    public function getCharsetName(): string {}
+    public function getCollationName(): string {}
+}
+```
+
+```
+class InformationSchema\Table\IntColumn extends Column
+{
+    public const TYPE = 'INT';
+
     public function isUnsigned(): bool {}
     public function getPadding(): int {}
     public function getType(): IntEnum {}
@@ -88,18 +92,24 @@ class InformationSchema\Table\IntegerColumn extends Column
 ```
 
 ```
-class InformationSchema\Table\DecimalColumn extends Column
+class InformationSchema\Table\FloatColumn extends Column
 {
+    public const TYPE = 'FLOAT';
+
     public function getDefaultValue() {}
     public function getScale(): int {}
     public function getPrecision(): int {}
+    public function getNumericScale(): int {}
 }
 ```
 
 ```
-class InformationSchema\Table\DateTimeColumn extends Column
+class InformationSchema\Table\DateColumn extends Column
 {
+    public const TYPE = 'DATE';
+
     public function getDefaultValue(): string {}
+    public function getDatetimePrecision(): int {}
 }
 ```
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -27,14 +27,274 @@ MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
 
 ## Design
 
-Introduce concept of database adapters to allow normalize values in declarative schema for different databases.
-
-`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+Introduce new interfaces under Db namespace that allow to manage table schema, refactor implementations of the following interfaces in declarative schema to use interfaces under Db namespace.
 
 Similar approach need to be taken for clients of the following interfaces
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+
+Revise implementation of these interfaces to see if anything need to be changed here
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
+
+New interfaces and types for managing table schema.
+
+```
+class ConstraintType extends \SplEnum
+{
+    const primary = 'primary';
+    const unique = 'unique';
+    const auto_increment = 'auto_increment';
+}
+```
+
+```
+class IndexType extends \SplEnum
+{
+    // For MySQL, Oracle and Postgres will use btree
+    const normal = 'normal';
+
+    // For MySQL fulltext, one of text indexes for Oracle and text for Postgres
+    const text = 'text';
+}
+```
+
+```
+class OnDelete extends \SplEnum
+{
+    const cascade = 'cascade';
+}
+```
+
+```
+class CollationType extends \SplEnum
+{
+    const utf8 = 'utf8';
+}
+```
+
+```
+class Constraint
+{
+    public function getName(): string {}
+
+    /**
+     * @return string[]
+     */
+    public function getColumns() {}
+
+    public function getType(): ConstraintType {}
+}
+```
+
+```
+class Index
+{
+    public function getName(): string {}
+
+    /**
+     * @return string[]
+     */
+    public function getColumns() {}
+
+    public function getType(): IndexType {}
+}
+```
+
+```
+class ForeignKey
+{
+    public function getType(): string {}
+    public function getName(): string {}
+    public function getColumn(): string {}
+    public function getReferenceTable(): string {}
+    public function getReferenceColumn(): string {}
+    public function getOnDelete(): OnDelete {}
+}
+```
+
+```
+/**
+ * There is no option for engine. Do we want to support different engines, if so how to abstract them, normal/memory?
+ */
+class TableOptions
+{
+    public function getName(): string {}
+    public function getComment(): string {}
+
+    /**
+     * Potentially can be removed as well?
+     */
+    public function getCollation(): CollationType {}
+}
+```
+
+```
+class Column
+{
+    public function getName(): string {}
+    public function getType() {}
+    public function getIsNullable() {}
+    public function getExtra() {}
+    public function getComment() {}
+}
+```
+
+```
+class IntegerColumn extends Column
+{
+    public function getDefaultValue() {}
+    public function isUnsigned(): bool {}
+    public function getPadding(): int {}
+}
+```
+
+```
+class DecimalColumn extends Column
+{
+    public function getDefaultValue() {}
+    public function getScale(): int {}
+    public function getPrecision(): int {}
+}
+```
+
+```
+class DateTimeColumn extends Column
+{
+    public function getDefaultValue(): string {}
+}
+```
+
+```
+interface TableInformationInterface
+{
+    /**
+     * @return Constraint[]
+     */
+    public function getConstraints($tableName, $resource);
+
+    /**
+     * @return ForeignKey[]
+     */
+    public function getReferences($tableName, $resource);
+
+    /**
+     * @return Index[]
+     */
+    public function getIndexes($tableName, $resource);
+
+    /**
+     * @return Column
+     */
+    public function getColumns($tableName, $resource);
+
+    public function getTableOptions($tableName, $resource): TableOptions;
+}
+```
+
+```
+interface TableManagementInterface
+{
+    public function createTable(TableOptions $tableOptions, $resource);
+    public function dropTable($tableName, $resource);
+
+    /**
+     * @param string $tableName
+     * @param Column|IntegerColumn|DecimalColumn|DateTimeColumn $column
+     * @param $resource
+     */
+    public function addColumn($tableName, Column $column, $resource);
+    public function dropColumn($tableName, $columnName, $resource);
+    public function addIndex($tableName, Index $index, $resource);
+    public function dropIndex($tableName, $indexName, $resource);
+    public function addConstraint($tableName, Constraint $constraint, $resource);
+    public function dropConstraint($tableName, $constraintName, $resource);
+    public function addForeignKey($tableName, ForeignKey $foreignKey, $resource);
+    public function dropForeignKey($tableName, $foreignKeyName, $resource);
+    public function updateTableOptions($tableName, TableOptions $tableOptions, $resource);
+}
+```
+
+```
+class TableDiff
+{
+    public function getName(): string {}
+
+    /**
+     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
+     */
+    public function getAddedColumns() {}
+
+    /**
+     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
+     */
+    public function getChangedColumns() {}
+
+    /**
+     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
+     */
+    public function getRemovedColumns() {}
+
+    /**
+     * Index[]
+     */
+    public function getAddedIndexes() {}
+
+    /**
+     * Index[]
+     */
+    public function getChangedIndexes() {}
+
+    /**
+     * Index[]
+     */
+    public function getRemovedIndexes() {}
+
+    /**
+     * Constraint[]
+     */
+    public function getAddedConstraints() {}
+
+    /**
+     * Constraint[]
+     */
+    public function getChangedConstraints() {}
+
+    /**
+     * Constraint[]
+     */
+    public function getRemovedConstraints() {}
+
+    /**
+     * ForeignKey[]
+     */
+    public function getAddedForeignKeys() {}
+
+    /**
+     * ForeignKey[]
+     */
+    public function getChangedForeignKeys() {}
+
+    /**
+     * ForeignKey[]
+     */
+    public function getRemovedForeignKeys() {}
+
+    public function getFromTable(): string {}
+}
+```
+
+```
+/**
+ * Alternative interface
+ */
+interface TableManagementInterface
+{
+    public function createTable(TableOptions $tableOptions, $resource);
+    public function dropTable($tableName, $resource);
+    public function alterTable($tableName, $resource, TableDiff $tableDiff);
+}
+```
 
 Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
 
@@ -46,4 +306,4 @@ It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariad
 
 ## Considerations
 
-`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. Ideally we should have an interface that would return normalized data and be compatible with all databases. This is a much larger change and might be considered for minor release.
+`\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -47,11 +47,9 @@ class ConstraintType extends \SplEnum
 ```
 class IndexType extends \SplEnum
 {
-    // For MySQL, Oracle, MS SQL and Postgres will use btree
-    const normal = 'normal';
+    const btree = 'btree';
 
-    // For MySQL and MS SQL fulltext, one of text indexes for Oracle and text for Postgres
-    const text = 'text';
+    const fulltext = 'fulltext';
 }
 ```
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -113,7 +113,7 @@ class ForeignKey
 /**
  * There is no option for engine. Do we want to support different engines, if so how to abstract them, normal/memory?
  */
-class TableOptions
+class Table
 {
     public function getName(): string {}
     public function getComment(): string {}
@@ -167,17 +167,32 @@ interface InformationSchema\Table\ConstraintInterface
     /**
      * @return Constraint[]
      */
-    public function getConstraints($tableName, $resource);
+    public function getConstraints($tableName, $connectionName);
+
+    /**
+     * @return Constraint
+     */
+    public function getConstraintByName($tableName, $constraintName, $connectionName);
 }
 ```
 
 ```
-interface InformationSchema\Table\ReferenceInterface
+interface InformationSchema\Table\ForeignKeyInterface
 {
     /**
      * @return ForeignKey[]
      */
-    public function getReferences($tableName, $resource);
+    public function getForeignKeys($tableName, $connectionName);
+    
+    /**
+     * @return ForeignKey
+     */
+    public function getForeignKeyByName($tableName, $foreignKeyName, $connectionName);
+    
+    /**
+     * @return ForeignKey[]
+     */
+    public function getForeignKeyForTable($tableName, $connectionName);
 }
 ```
 
@@ -187,7 +202,12 @@ interface InformationSchema\Table\IndexInterface
     /**
      * @return Index[]
      */
-    public function getIndexes($tableName, $resource);
+    public function getIndexes($tableName, $connectionName);
+    
+    /**
+     * @return Index
+     */
+    public function getIndexByName($tableName, $indexName, $connectionName);
 }
 ```
 
@@ -197,14 +217,14 @@ interface InformationSchema\Table\ColumnInterface
     /**
      * @return Column
      */
-    public function getColumns($tableName, $resource);
+    public function getColumns($tableName, $connectionName);
 }
 ```
 
 ```
-interface InformationSchema\Table\OptionsInterface
+interface InformationSchema\TableInterface
 {
-    public function getTableOptions($tableName, $resource): TableOptions;
+    public function getInformation($tableName, $connectionName): Table;
 }
 ```
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -51,10 +51,10 @@ class ConstraintType extends \SplEnum
 ```
 class IndexType extends \SplEnum
 {
-    // For MySQL, Oracle and Postgres will use btree
+    // For MySQL, Oracle, MS SQL and Postgres will use btree
     const normal = 'normal';
 
-    // For MySQL fulltext, one of text indexes for Oracle and text for Postgres
+    // For MySQL and MS SQL fulltext, one of text indexes for Oracle and text for Postgres
     const text = 'text';
 }
 ```
@@ -296,6 +296,19 @@ interface TableManagementInterface
 }
 ```
 
+### Alternative approach
+
+Alternative approach is to reuse existing interfaces and add replaceability on the level of declarative schema.
+
+`\Magento\Framework\Setup\Declaration\Schema\Db\SchemaBuilder` should accept `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` that would allow to create database specific implementations of `DbSchemaReaderInterface` for given connection. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderFactory` will depend on `\Magento\Framework\App\DeploymentConfig` to get configuration for connection, `model` will contain name of database adapter.
+
+Similar approach need to be taken for clients of the following interfaces
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
+
+### Replaceability of `\Magento\Framework\DB\Adapter\AdapterInterface`
+
 Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
 
 `\Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface` currently returns instance of `Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface` that is defined by preference, similarly to approach above it should resolve database specific adapter based on configuration.
@@ -307,3 +320,5 @@ It has default value of `mysql4`. I propose to add 2 values: `mysql` and `mariad
 ## Considerations
 
 `\Magento\Framework\DB\Adapter\AdapterInterface` has methods like `describeTable` which return raw values from database engine. This is leaky interface. We should have interfaces that return normalized data and are compatible with all databases. Methods that don't return normalized data need to be deprecated on `\Magento\Framework\DB\Adapter\AdapterInterface`.
+
+`engine` field in declarative schema need to be deprecated.

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -27,11 +27,7 @@ MySQL returns NULL for COLUMN_DEFAULT and MariaDB returns NULL as a string.
 
 ## Design
 
-Introduce new interfaces under Db namespace that allow to manage table schema, refactor implementations of the following interfaces in declarative schema to use interfaces under Db namespace.
-
-Similar approach need to be taken for clients of the following interfaces
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface`
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
+Introduce new interfaces under Db namespace that allow to allow get information about table schema, refactor implementations of `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface` in declarative schema to use interfaces under Db namespace.
 
 Revise implementation of these interfaces to see if anything need to be changed here
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
@@ -166,135 +162,53 @@ class DateTimeColumn extends Column
 ```
 
 ```
-interface TableInformationInterface
+interface InformationSchema\Table\ConstraintInterface
 {
     /**
      * @return Constraint[]
      */
     public function getConstraints($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\ReferenceInterface
+{
     /**
      * @return ForeignKey[]
      */
     public function getReferences($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\IndexInterface
+{
     /**
      * @return Index[]
      */
     public function getIndexes($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\ColumnInterface
+{
     /**
      * @return Column
      */
     public function getColumns($tableName, $resource);
+}
+```
 
+```
+interface InformationSchema\Table\OptionsInterface
+{
     public function getTableOptions($tableName, $resource): TableOptions;
 }
 ```
 
-```
-interface TableManagementInterface
-{
-    public function createTable(TableOptions $tableOptions, $resource);
-    public function dropTable($tableName, $resource);
-
-    /**
-     * @param string $tableName
-     * @param Column|IntegerColumn|DecimalColumn|DateTimeColumn $column
-     * @param $resource
-     */
-    public function addColumn($tableName, Column $column, $resource);
-    public function dropColumn($tableName, $columnName, $resource);
-    public function addIndex($tableName, Index $index, $resource);
-    public function dropIndex($tableName, $indexName, $resource);
-    public function addConstraint($tableName, Constraint $constraint, $resource);
-    public function dropConstraint($tableName, $constraintName, $resource);
-    public function addForeignKey($tableName, ForeignKey $foreignKey, $resource);
-    public function dropForeignKey($tableName, $foreignKeyName, $resource);
-    public function updateTableOptions($tableName, TableOptions $tableOptions, $resource);
-}
-```
-
-```
-class TableDiff
-{
-    public function getName(): string {}
-
-    /**
-     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
-     */
-    public function getAddedColumns() {}
-
-    /**
-     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
-     */
-    public function getChangedColumns() {}
-
-    /**
-     * Column[]|IntegerColumn[]|DecimalColumn[]|DateTimeColumn[]
-     */
-    public function getRemovedColumns() {}
-
-    /**
-     * Index[]
-     */
-    public function getAddedIndexes() {}
-
-    /**
-     * Index[]
-     */
-    public function getChangedIndexes() {}
-
-    /**
-     * Index[]
-     */
-    public function getRemovedIndexes() {}
-
-    /**
-     * Constraint[]
-     */
-    public function getAddedConstraints() {}
-
-    /**
-     * Constraint[]
-     */
-    public function getChangedConstraints() {}
-
-    /**
-     * Constraint[]
-     */
-    public function getRemovedConstraints() {}
-
-    /**
-     * ForeignKey[]
-     */
-    public function getAddedForeignKeys() {}
-
-    /**
-     * ForeignKey[]
-     */
-    public function getChangedForeignKeys() {}
-
-    /**
-     * ForeignKey[]
-     */
-    public function getRemovedForeignKeys() {}
-
-    public function getFromTable(): string {}
-}
-```
-
-```
-/**
- * Alternative interface
- */
-interface TableManagementInterface
-{
-    public function createTable(TableOptions $tableOptions, $resource);
-    public function dropTable($tableName, $resource);
-    public function alterTable($tableName, $resource, TableDiff $tableDiff);
-}
-```
+Management interfaces will not be introduced.
 
 ### Alternative approach
 

--- a/design-documents/declarative-schema-database-compatibility.md
+++ b/design-documents/declarative-schema-database-compatibility.md
@@ -6,13 +6,13 @@ Declarative schema relies on querying data that may have different format depend
 
 ```
 SELECT 
-	COLUMN_NAME as 'name',
-	COLUMN_DEFAULT as 'default',
-	DATA_TYPE as 'type',
-	IS_NULLABLE as 'nullable',
-	COLUMN_TYPE as 'definition',
-	EXTRA as 'extra',
-	COLUMN_COMMENT as 'comment'
+    COLUMN_NAME as 'name',
+    COLUMN_DEFAULT as 'default',
+    DATA_TYPE as 'type',
+    IS_NULLABLE as 'nullable',
+    COLUMN_TYPE as 'definition',
+    EXTRA as 'extra',
+    COLUMN_COMMENT as 'comment'
 FROM
     information_schema.COLUMNS
 WHERE
@@ -34,7 +34,7 @@ Introduce concept of database adapters to allow normalize values in declarative 
 Similar approach need to be taken for clients of the following interfaces
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DDLTriggerInterface`
 1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaWriterInterface`
-1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface`
+1. `\Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface` (see usages of `\Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator`)
 
 Not needed for declarative schema, but with this refactoring would also make sense to add ability have different adapters for different databases.
 


### PR DESCRIPTION
## Problem
This is a subset of #264 , covering only COLUMNS and TABLES interfaces.

Different RDBMS return Information Schema (metadata) information in different format. Magento framework should allow to switch between different implementations in order to support those different versions of DBs, as well as differences between versions.

## Solution
Introduce granular interfaces, based in Information Schema standard (looking into MySQL and MariaDB definitions in this scope, links are in the document). Application can switch between different implementation based on the profile.