### PR TITLE
MC-22136: UrlResolver identifier

### DIFF
--- a/design-documents/graph-ql/coverage/url-resolver-identifier.md
+++ b/design-documents/graph-ql/coverage/url-resolver-identifier.md
@@ -47,8 +47,23 @@ This ID has to be filterable in all entities, even in product
      }
    }
  ```
-As of now this feature is not possible, but it has to be introduced to unlock this flow.
+ 
+  ```graphql
+  products(filter: { id: { in: ["ID1", "ID2", "ID3"]}}) {
+      items {
+        id
+        name
+      }
+    }
+  ```
+  
+This is not currently available in current schema, but it has to be introduced to unlock this flow.
 A separate proposal for product will be requested.
+
+ #### Intended functionality
+ 
+- If only id is passed, bypass the current Search API and fetch data directly from DB
+- If id + other filters are passed, consider this an unsupported case. To be implemented later . Throw an exception in case of such query. This case is intended to be implemented as a separate task.
 
  ## Alternatives
  

--- a/design-documents/graph-ql/coverage/url-resolver-identifier.md
+++ b/design-documents/graph-ql/coverage/url-resolver-identifier.md
@@ -3,15 +3,15 @@
  
 In the client flow, for PWA, in order to load a entity/template, one must make a query to the `urlResolver` to obtain the *id* and *Entity Type* of the content that can be Product, Category or CMS.
 
-####Example:
-#####Request:
+#### Example:
+##### Request:
 ```graphql
 urlResolver(url: "/breathe-easy-tank") {
   id
   type
 }
 ```
-#####Response:
+##### Response:
 ```json
 {
   "data": {
@@ -28,12 +28,50 @@ Also we want not to expose database autoincrement ID in graphql in the future be
 
  ## Proposed solution
 
-Deprecate `id` field from `urlResolver` and introduce a new field called identifier, unique to each entity that's not the Id from the database.
 
 ```graphql
-urlResolver(url: String) {
-  id: Int @deprecated
+urlResolverV2(url: String) {
+  id: ID!
+  ....
+}
+```
+
+This ID has to be filterable in all entities, even in product
+
+ ```graphql
+ products(filter: { id: { eq: []"$valueOfIdentifierFromUrlResolver"}}) {
+     items {
+       id
+       name
+     }
+   }
+ ```
+As of now this feature is not possible, but it has to be introduced to unlock this flow.
+
+ ## Alternatives
+ 
+ ##### #1
+ We can directly return the entity instead of returning the identifier from UrlResolver.
+ There's a different proposal fot this in [storefront-route.md](https://github.com/magento/architecture/blob/master/design-documents/graph-ql/coverage/storefront-route.md)
+ 
+ We can introduce an interface called ResolvedEntityInterface that returns the actual object.
+ That means that we either wrap all supported entities into an object and use fragments or all existing objects will have to implement this empty interface.
+ 
+  ```graphql
+ interface ResolvedEntityInterface {
+ 
+ }
+  ```
+  
+  We may need to keep urlResolverV2 and it's field `id` and introduce `urlResolverV2` as type for client-side caching. This might require a closer look to expose affected areas.
+  
+  
+ ##### #2
+  We could Deprecate `id` field from `urlResolver` and introduce a new field called identifier, unique to each entity that's not the Id from the database.
+```graphql
+urlResolverV2(url: String) {
   identifier: String!
+  ....
 }
 ```
 
@@ -52,20 +90,3 @@ Where `identifier` represents:
      }
    }
  ```
-
- ## Alternatives
- 
- We can directly return the entity instead of returning the identifier from UrlResolver.
- There's a different proposal fot this in [storefront-route.md](https://github.com/magento/architecture/blob/master/design-documents/graph-ql/coverage/storefront-route.md)
- 
- We can introduce an interface called ResolvedEntityInterface that returns the actual object.
- That means that we either wrap all supported entities into an object and use fragments or all existing objects will have to implement this empty interface.
- 
-  ```graphql
- interface ResolvedEntityInterface {
- 
- }
-  ```
-  
-  We may need to keep urlResolverV2 and it's field `id` and introduce `urlResolverV2` as type for client-side caching. This might require a closer look to expose affected areas.
-  

--- a/design-documents/graph-ql/coverage/url-resolver-identifier.md
+++ b/design-documents/graph-ql/coverage/url-resolver-identifier.md
@@ -38,15 +38,6 @@ urlResolverV2(url: String) {
 ```
 
 This ID has to be filterable in all entities, even in product
-
- ```graphql
- products(filter: { id: { eq: "$valueOfIdentifierFromUrlResolver"}}) {
-     items {
-       id
-       name
-     }
-   }
- ```
  
   ```graphql
   products(filter: { id: { in: ["ID1", "ID2", "ID3"]}}) {
@@ -56,9 +47,6 @@ This ID has to be filterable in all entities, even in product
       }
     }
   ```
-  
-This is not currently available in current schema, but it has to be introduced to unlock this flow.
-A separate proposal for product will be requested.
 
  #### Intended functionality
  

--- a/design-documents/graph-ql/coverage/url-resolver-identifier.md
+++ b/design-documents/graph-ql/coverage/url-resolver-identifier.md
@@ -1,0 +1,68 @@
+ # UrlResolver identifier 
+ ## Problem statement   
+ 
+In the client flow, for PWA, in order to load a entity/template, one must make a query to the `urlResolver` to obtain the *id* and *Entity Type* of the content that can be Product, Category or CMS.
+
+####Example:
+#####Request:
+```graphql
+urlResolver(url: "/breathe-easy-tank") {
+  id
+  type
+}
+```
+#####Response:
+```json
+{
+  "data": {
+    "urlResolver": {
+      "id": 1820,
+      "type": "PRODUCT"
+    }
+  }
+}
+```
+
+Currently we can't use this Id in Product to filter by, because of how Search API works, also CMS has another unique identifier that can be used.
+Also we want not to expose database autoincrement ID in graphql in the future because of replacements with UUID.
+
+ ## Proposed solution
+
+Deprecate `id` field from `urlResolver` and introduce a new field called identifier, unique to each entity that's not the Id from the database.
+
+```graphql
+urlResolver(url: String) {
+  id: Int @deprecated
+  identifier: String!
+}
+```
+
+Where `identifier` represents:
+ 
+ - `sku` value - if Entity is a product
+ - `id` value - if Entity is a category
+ - `identifier` value - if Entity is a cms page (naming coincidence)
+ 
+ We then can use this identifier to query the Product, Category or CmsPage
+ ```graphql
+ products(filter: { sku: "$valueOfIdentifierFromUrlResolver"}) {
+     items {
+       id
+       name
+     }
+   }
+ ```
+
+ ## Alternatives
+ 
+ We can directly return the entity instead of returning the identifier from UrlResolver.
+ We can introduce an interface called ResolvedEntityInterface that returns the actual object.
+ That means that we either wrap all supported entities into an object and use fragments or all existing objects will have to implement this empty interface.
+ 
+  ```graphql
+ interface ResolvedEntityInterface {
+ 
+ }
+ 
+ 
+  ```

--- a/design-documents/graph-ql/coverage/url-resolver-identifier.md
+++ b/design-documents/graph-ql/coverage/url-resolver-identifier.md
@@ -28,18 +28,19 @@ Also we want not to expose database autoincrement ID in graphql in the future be
 
  ## Proposed solution
 
+Introduction of `urlResolverV2` and deprecation of `urlResolver`. We want to keep the same id name, but change the type, and do this in a backward compatible way. So a new query is needed.
 
 ```graphql
 urlResolverV2(url: String) {
   id: ID!
-  ....
+  ...
 }
 ```
 
 This ID has to be filterable in all entities, even in product
 
  ```graphql
- products(filter: { id: { eq: []"$valueOfIdentifierFromUrlResolver"}}) {
+ products(filter: { id: { eq: "$valueOfIdentifierFromUrlResolver"}}) {
      items {
        id
        name
@@ -47,6 +48,7 @@ This ID has to be filterable in all entities, even in product
    }
  ```
 As of now this feature is not possible, but it has to be introduced to unlock this flow.
+A separate proposal for product will be requested.
 
  ## Alternatives
  

--- a/design-documents/graph-ql/coverage/url-resolver-identifier.md
+++ b/design-documents/graph-ql/coverage/url-resolver-identifier.md
@@ -56,6 +56,8 @@ Where `identifier` represents:
  ## Alternatives
  
  We can directly return the entity instead of returning the identifier from UrlResolver.
+ There's a different proposal fot this in [storefront-route.md](https://github.com/magento/architecture/blob/master/design-documents/graph-ql/coverage/storefront-route.md)
+ 
  We can introduce an interface called ResolvedEntityInterface that returns the actual object.
  That means that we either wrap all supported entities into an object and use fragments or all existing objects will have to implement this empty interface.
  
@@ -63,6 +65,7 @@ Where `identifier` represents:
  interface ResolvedEntityInterface {
  
  }
- 
- 
   ```
+  
+  We may need to keep urlResolverV2 and it's field `id` and introduce `urlResolverV2` as type for client-side caching. This might require a closer look to expose affected areas.
+  


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
In reference to usage of Id in product search that became deprecated, we need an identifier to replace the ID as Int in urlResolver. This can be any unique identifier for Product, Category and CMS that can be later used to query the actual entity.

## Solution
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

Deprecate EntityUrl.id
Add new field to EntityUrl called identifier
Return sku for EntityUrl.identifier on product, and match id for other entities

This is the Architectural proposal needed for changes

Other idea is to add filter by id back to product filter, because we did not keep backward compatibility by removing it, problem is that Id it's not part of search index right now, and we don't want it to be.


## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
