### PR TITLE
magento/graphql-ce#196: Swatches: expose Hex color code and swatch images

### DIFF
--- a/design-documents/graph-ql/coverage/Swatches.graphqls
+++ b/design-documents/graph-ql/coverage/Swatches.graphqls
@@ -1,0 +1,19 @@
+type ConfigurableProductOptionsValues {
+    swatch_data: SwatchDataInterface @doc(description: "Swatch data for configurable product option")
+}
+
+interface SwatchDataInterface {
+    value: String @doc(description: "Value of swatch item (HEX color code, image link or textual value)")
+}
+
+type ImageSwatchData implements SwatchDataInterface {
+    thumbnail: String @doc(description: "Thumbnail swatch image URL")
+}
+
+type TextSwatchData implements SwatchDataInterface {
+
+}
+
+type ColorSwatchData implements SwatchDataInterface {
+
+}


### PR DESCRIPTION
## Solution
Proposed schema for adding swatch data for configurable options.
``` graphql
{
  products(filter: {sku: {eq: "configurable-product"}}) {
    items {
      ... on ConfigurableProduct{    
      configurable_options{
          values {
            label
            swatch_data{
              value
            }
          } 
        }
      }
    }
  }
}
```
## Side notes
- This approach does not align with [current implementation of product swatches](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/SwatchesGraphQl/etc/schema.graphqls), but is semantically correct.
- Current implementation of product swatches cannot be changed in order to use `SwatchDataInterface` due to BC.

## Requested Reviewers
@akaplya 
@paliarush 
