### PR TITLE
updateCustomerV2 code style fixes

### DIFF
--- a/design-documents/graph-ql/coverage/customer-email-password-update.md
+++ b/design-documents/graph-ql/coverage/customer-email-password-update.md
@@ -15,7 +15,7 @@ Deprecate `updateCustomer` mutation in favor of `updateCustomerV2`. `CustomerUpd
 
  ```graphql
  mutation {
-    updateCustomerV2(input: CustomerUpdateInput!): Customer
+    updateCustomerV2(input: CustomerUpdateInput!): CustomerOutput
  }
  
  type CustomerUpdateInput {
@@ -36,7 +36,7 @@ Deprecate `updateCustomer` mutation in favor of `updateCustomerV2`. `CustomerUpd
  
  ```graphql
   mutation {
-     updateCustomerEmail(email: String!, password: String!): Customer
+     updateCustomerEmail(email: String!, password: String!): CustomerOutput
   }
  ```
  
@@ -44,7 +44,7 @@ Deprecate `updateCustomer` mutation in favor of `updateCustomerV2`. `CustomerUpd
  
  ```graphql
   mutation {
-     updateCustomerPassword(password: String!, old_password: String!): Customer
+     updateCustomerPassword(currentPassword: String!, newPassword: String!): CustomerOutput
   }
  ```
  

--- a/design-documents/graph-ql/coverage/customer-email-password-update.md
+++ b/design-documents/graph-ql/coverage/customer-email-password-update.md
@@ -18,7 +18,7 @@ Deprecate `updateCustomer` mutation in favor of `updateCustomerV2`. `CustomerUpd
     updateCustomerV2(input: CustomerUpdateInput!): CustomerOutput
  }
  
- type CustomerUpdateInput {
+ input CustomerUpdateInput {
      date_of_birth: String
      dob: String
      firstname: String
@@ -39,15 +39,7 @@ Deprecate `updateCustomer` mutation in favor of `updateCustomerV2`. `CustomerUpd
      updateCustomerEmail(email: String!, password: String!): CustomerOutput
   }
  ```
- 
- **updateCustomerPassword**
- 
- ```graphql
-  mutation {
-     updateCustomerPassword(currentPassword: String!, newPassword: String!): CustomerOutput
-  }
- ```
- 
+
  ### Alternative solution
  
  Alternative solution is to use existing field consistently for setting new customer password and introduce additional input argument for current password verification:


### PR DESCRIPTION
## Problem
- Propose schema is inconsistent with existing one. `CustomerOutput` already exists and is used in `createCustomer (input: CustomerInput!): CustomerOutput` mutation.
``` graphql
type CustomerOutput {
    customer: Customer!
}
```
- Removed `updateCustomerPassword` because `changeCustomerPassword(currentPassword: String!, newPassword: String!): Customer` already exists
## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
@paliarush 
@melnikovi 