### PR TITLE
Update product review graphql schema

### DIFF
--- a/design-documents/graph-ql/coverage/product-reviews.graphqls
+++ b/design-documents/graph-ql/coverage/product-reviews.graphqls
@@ -1,7 +1,7 @@
 type Customer {
     reviews(
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once."),
-        currentPage: Int = 1 @doc(description: "Specifies which page of results to return."),
+        currentPage: Int = 1 @doc(description: "Specifies which page of results to return.")
     ): ProductReviews!
 }
 
@@ -11,29 +11,32 @@ type ProductInterface {
     reviews(
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once."),
         currentPage: Int = 1 @doc(description: "Specifies which page of results to return."),
-    ): ProductReviews!
+        sort: ReviewSortInput @doc(description: "Specifies which field to sort on, and whether to return the results in ascending or descending order.")
+    ): ProductReviews! @doc(description: "ProductReview returns an array containing approved product reviews")
 }
 
 type ProductReviews {
     items: [ProductReview]! @doc(description: "An array of product reviews.")
     page_info: SearchResultPageInfo! @doc(description: "Metadata for pagination rendering.")
+    total_count: Int @doc(description: "The number of product reviews returned")
 }
 
 type ProductReview @doc(description: "Details of a product review") {
+    review_id: Int! @doc(description: "The ID assigned to the review")
     product: ProductInterface! @doc(description: "Contains details about the reviewed product")
-    summary: String! @doc(description: "The review summary (a.k.a title")
-    text: String! @doc(description: "The review text.")
+    title: String! @doc(description: "The review title")
+    review_text: String! @doc(description: "The review text.")
     nickname: String! @doc(description: "The customer's nickname. Defaults to customer name if logged in.")
     created_at: String! @doc(description: "Date indicating when the review was created.")
     average_rating: Float! @doc(description: "The average rating for product review.")
-    ratings_breakdown: [ProductReviewRating!]! @doc(description: "An array of ratings by rating category. For example quality, price.")
+    ratings: [ProductReviewRating!]! @doc(description: "An array of ratings by rating category. For example Quality, Price.")
 }
 
 type ProductReviewRating {
-    name: String! @doc(description: "The review rating name for example quality, price.")
-    value: String! @doc(description: "The rating value given by customer. Possible values by default: 1 to 5.")
+    name: String! @doc(description: "The review rating name. For example Quality, Price.")
+    percent: Float! @doc(description: "The rating percent given by customer to the review")
+    value: Int! @doc(description: "The rating value given by customer. Possible values by default: 1 to 5.")
 }
-
 
 type Query {
     productReviewRatingsMetadata(): ProductReviewRatingsMetadata! @doc(description: "Metadata required by clients to render ratings & reviews section.")
@@ -45,13 +48,13 @@ type ProductReviewRatingsMetadata {
 
 type ProductReviewRatingMetadata {
     id: String! @doc(description: "Base 64 encoded rating id.")
-    name: String! @doc(description: "The review rating name for example quality, price")
+    name: String! @doc(description: "The review rating name. For example Quality, Price")
     values: [ProductReviewRatingValueMetadata!]! @doc(description: "List of product review ratings sorted based on position.")
 }
 
 type ProductReviewRatingValueMetadata {
     value_id: String! @doc(description: "Base 64 encoded rating value id.")
-    value: String! @doc(description: "e.g Good, Perfect, 3, 4, 5")
+    value: Int!@doc(description: "The rating value. Possible values: 1, 2, 3, 4, 5")
 }
 
 type Mutation {
@@ -65,12 +68,17 @@ type CreateProductReviewOutput {
 input CreateProductReviewInput {
     sku: String! @doc(description: "The SKU of the product that the review is assigned")
     nickname: String! @doc(description: "The customer's nickname. Defaults to customer name if logged in.")
-    summary: String! @doc(description: "The review summary (a.k.a title")
-    text: String! @doc(description: "The review text.")
-    ratings: [ProductReviewRatingInput!]! @doc(description: "Ratings details by category. e.g price: 5, quality: 4 etc")
+    title: String! @doc(description: "The review title")
+    review_text: String! @doc(description: "The review text.")
+    ratings: [ProductReviewRatingInput!]! @doc(description: "Ratings details by category. e.g Price: 5, Quality: 4, etc")
 }
 
 type ProductReviewRatingInput {
     id: String! @doc(description: "Base 64 encoded rating id.")
     value_id: String! @doc(description: "Base 64 encoded rating value id.")
+}
+
+input ReviewSortInput @doc(description: "Specifies the field to use for sorting results and indicates whether the results are sorted in ascending or descending order") {
+    created_at: SortEnum @doc(description: "Timestamp indicating when the product review was created")
+    average_rating: SortEnum @doc(description: "Average rating of the review.")
 }


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->

1. Can not sort reviews by other fields
1. Reviews query does not return totals reviews
1. Unable to access review detail page from customer account as the route requires review id.
1. Keep field naming consistency.
1. Missing rating percent from review ratings.
1. Usage of "String" field type instead of "Int" when it is not the case.

## Solution

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

1. Review sort order
	- useful if we want to create a listing/widget with top 5 product reviews
	- default will be "created_at" DESC
	
1. Add "total_count" field for "ProductReviews"
	- needed to display review totals when listing product reviews in customer account
	
1. Add field "review_id" to "ProductReview"
	- needed if we want to keep the review detail page from customer account. See route "review/customer/view/id/[REVIEW_ID]" (Ex: https:www.example.com/review/customer/view/id/1/). If this page can be eliminated we can drop this field.
	
1. Rename "ProductReview" field "summary" with "title" and field "text" with "review_text"
	- this is to keep them alligned with https://github.com/magento/magento2/pull/19266/files
1. Rename "CreateProductReviewInput" field "summary" with "title" and field "text" with "review_text"
	- this is to keep them alligned with https://github.com/magento/magento2/pull/19266/files

1. Rename "ProductReview" field "ratings_breakdown" with "ratings".
	- keep naming consitency with same field from "CreateProductReviewInput"
	- keep field naming as intuitive as possible
	
1. Add percent field to "ProductReviewRating"
	- help to avoid calculations in frontend area if the value for this field is needed for frontend logic.
	
1. Change "ProductReviewRating" field type from "string" to "int".
	- there is not need to have field type as string when Magento Core predefined values are 1 to 5 and does not allows doe users to add new values.
	
1. Change "value_id" field from "ProductReviewRatingValueMetadata" to int instead of string
	- there is not need to have field type as string when Magento Core predefined values are 1 to 5 and does not allows doe users to add new values.

Note: Instead of base64 encoded values for ratings we can use the rating "Default Value" which is unique across the system, but that will mean adding a separate field for store label.

```graphql
type ProductReviewRatingMetadata {
    id: String! @doc(description: "Base 64 encoded rating id.")
    name: String! @doc(description: "The review rating name. For example Quality, Price")
    label: String! @doc(description: "The review rating store label.")
    values: [ProductReviewRatingValueMetadata!]! @doc(description: "List of product review ratings sorted based on position.")
}
```

instead of 
```graphql
type ProductReviewRatingMetadata {
    id: String! @doc(description: "Base 64 encoded rating id.")
    name: String! @doc(description: "The review rating name. For example Quality, Price")
    values: [ProductReviewRatingValueMetadata!]! @doc(description: "List of product review ratings sorted based on position.")
}
```

That would mean "ProductReviewRatingInput " will look like this:
```graphql
type ProductReviewRatingInput {
    name: String! @doc(description: "The review rating name. For example Quality, Price")
    value: Int! @doc(description: "The rating value. Possible values: 1, 2, 3, 4, 5")
}
```
	
## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->

@naydav 
@paliarush 
@lenaorobei 
