### PR TITLE
Support pagination in category filtering

### DIFF
--- a/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
+++ b/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
@@ -4,7 +4,7 @@ type Query {
         filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
     ): [CategoryTree] @doc(description: "Categories tree.")
 
-    categoryV2(
+    categories(
         filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional.")
         currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1.")
@@ -17,6 +17,7 @@ input CategoryFilterInput  @doc(description: "CategoryFilterInput defines the fi
     url_key: FilterEqualTypeInput @doc(description: "Filter by the part of the URL that identifies the category.")
     name: FilterMatchTypeInput @doc(description: "Filter by the display name of the category.")
     url_path: FilterEqualTypeInput @doc(description: "Filter by the URL path for the category.")
+    path: FilterMatchTypeInput @doc(description: "Filter by category path.")
 }
 
 type CategoryResult @doc(description: "Collection of CategoryTree object and pagination information.") {

--- a/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
+++ b/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
@@ -18,6 +18,7 @@ input CategoryFilterInput  @doc(description: "CategoryFilterInput defines the fi
     name: FilterMatchTypeInput @doc(description: "Filter by the display name of the category.")
     url_path: FilterEqualTypeInput @doc(description: "Filter by the URL path for the category.")
     path: FilterMatchTypeInput @doc(description: "Filter by category path.")
+    canonical_url: FilterEqualTypeInput @doc(description: "Filter by canonical URL of the category.")
 }
 
 type CategoryResult @doc(description: "Collection of CategoryTree object and pagination information.") {

--- a/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
+++ b/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
@@ -8,7 +8,7 @@ type Query {
         filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional.")
         currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1.")
-    ): [CategoryResult]
+    ): CategoryResult
 }
 
 input CategoryFilterInput  @doc(description: "CategoryFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.")

--- a/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
+++ b/design-documents/graph-ql/coverage/CategoryFiltering.graphqls
@@ -1,15 +1,26 @@
 
- # added Category List Query.
+type Query {
+    categoryList(
+        filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
+    ): [CategoryTree] @doc(description: "Categories tree.")
 
-type Query CategoryList(
-filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
-): [CategoryTree] @doc(description: "Categories tree.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
-
-# added CategoryFilterInput with id, url_key and name as input filters.
+    categoryV2(
+        filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
+        pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional.")
+        currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1.")
+    ): [CategoryResult]
+}
 
 input CategoryFilterInput  @doc(description: "CategoryFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.")
 {
-    ids: FilterEqualTypeInput @doc(description: "Filter by category ID that uniquely identifies and filters the category."),
-    url_key: FilterEqualTypeInput @doc(description: "Filter by the part of the URL that identifies the category"),
+    ids: FilterEqualTypeInput @doc(description: "Filter by category ID that uniquely identifies and filters the category.")
+    url_key: FilterEqualTypeInput @doc(description: "Filter by the part of the URL that identifies the category.")
     name: FilterMatchTypeInput @doc(description: "Filter by the display name of the category.")
+    url_path: FilterEqualTypeInput @doc(description: "Filter by the URL path for the category.")
+}
+
+type CategoryResult @doc(description: "Collection of CategoryTree object and pagination information.") {
+    items: [CategoryTree] @doc(description: "List of categories that match filter criteria.")
+    page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query.")
+    total_count: Int @doc(description: "The total number of categories that match the criteria.")
 }


### PR DESCRIPTION
## Problem
Current `categoryList` query does not support pagination. Furthermore it is not possible to add pagination to this query in a backward compatible way, because the result is an array of categories with no reasonable place to put pagination information.

## Solution
Introduce a new category query `categories` that will allow for filtering as well as pagination. The result object follows the schema of other queries that include filtering/pagination (e.g. `products`).

## Requested Reviewers
@paliarush 
@akaplya 
