### PR TITLE
Provide option details

### DIFF
--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -48,15 +48,15 @@ Entered options:
 - Customizable options such as text field, file, etc
 - Gift Card (amount)
   
-### Option implementation
+#### Option implementation
   
 Product schema should be extended in order to provide option UUID.
 
-Option UUID is `base64` encoded string, that pack details for each option and in most cases is can be preseneted as 
+Option UUID is `base64` encoded string, that encodes details for each option and in most cases can be presented as 
 `base64("<option-type>/<option-id>/<option-value-id>")`
-For example, for customizable drop-down option "Color(id = 1), with values Red (id=1, Green=2)" UUID for Color:Red will looks like `"Y3VzdG9tLW9wdGlvbi8xLzE=" => base64("custom-option/1/1")` 
+For example, for customizable drop-down option "Color(id = 1), with values Red(id = 1), Green(id = 2)" UUID for Color:Red will looks like `"Y3VzdG9tLW9wdGlvbi8xLzE=" => base64("custom-option/1/1")` 
 
-Here is a GQL query that shows where need to add new field "uuid: String!" to cover existing cases:
+Here is a GQL query that shows how to add a new field "uuid: String!" to cover existing cases:
 
 
 ``` graphql

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -32,7 +32,7 @@ Each product may have options. Option can be of 2 types (see example below):
 ```
 
 We can consider "Selected Option" and "ID for Entered Option" as UUID. They meet the criteria:
-- Represent specific option. 
+- "Selected Option" represents option value, while "ID for Entered Option" represents option
 - Must be unique across different options
 - Returned from server
 - Used by client as is

--- a/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
+++ b/design-documents/graph-ql/coverage/add-items-to-cart-single-mutation.md
@@ -32,6 +32,7 @@ Each product may have options. Option can be of 2 types (see example below):
 ```
 
 We can consider "Selected Option" and "ID for Entered Option" as UUID. They meet the criteria:
+
 - "Selected Option" represents option value, while "ID for Entered Option" represents option
 - Must be unique across different options
 - Returned from server
@@ -50,13 +51,14 @@ Entered options:
   
 #### Option implementation
   
-Product schema should be extended in order to provide option UUID.
+Product schema should be extended in order to provide option identifier (aka first iteration of "UUID").
+Until introducing UUID lets name this identifier as *"id_v2"
 
-Option UUID is `base64` encoded string, that encodes details for each option and in most cases can be presented as 
+Option *id_v2* is `base64` encoded string, that encodes details for each option and in most cases can be presented as 
 `base64("<option-type>/<option-id>/<option-value-id>")`
-For example, for customizable drop-down option "Color(id = 1), with values Red(id = 1), Green(id = 2)" UUID for Color:Red will looks like `"Y3VzdG9tLW9wdGlvbi8xLzE=" => base64("custom-option/1/1")` 
+For example, for customizable drop-down option "Color(id = 1), with values Red(id = 1), Green(id = 2)" id_v2 for Color:Red will looks like `"Y3VzdG9tLW9wdGlvbi8xLzE=" => base64("custom-option/1/1")` 
 
-Here is a GQL query that shows how to add a new field "uuid: String!" to cover existing cases:
+Here is a GQL query that shows how to add a new field "id_v2: String!" to cover existing cases:
 
 
 ``` graphql
@@ -71,7 +73,7 @@ query {
           ... on CustomizableRadioOption {
             title
             value {
-              uuid # introduce new UUID field in CustomizableRadioValue
+              id_v2 # introduce new id_v2 field in CustomizableRadioValue
               option_type_id
               title
             }
@@ -79,7 +81,7 @@ query {
           ... on CustomizableDropDownOption {
             title
             value {
-              uuid # introduce new UUID field in CustomizableDropDownValue
+              id_v2 # introduce new id_v2 field in CustomizableDropDownValue
               # see \Magento\QuoteGraphQl\Model\Cart\BuyRequest\CustomizableOptionsDataProvider
               option_type_id
               title
@@ -90,7 +92,7 @@ query {
       }      ... on ConfigurableProduct {
         variants {
           attributes {
-            uuid # introduce new UUID field in ConfigurableAttributeOption  (format: configurable/<attribute-id>/<value_index>)
+            id_v2 # introduce new id_v2 field in ConfigurableAttributeOption  (format: configurable/<attribute-id>/<value_index>)
             # see \Magento\ConfigurableProductGraphQl\Model\Cart\BuyRequest\SuperAttributeDataProvider
             code
             value_index
@@ -98,7 +100,7 @@ query {
         }
       }      ... on DownloadableProduct {
         downloadable_product_links {
-          uuid #  introduce new UUID field in DownloadableProductLinks (format: downloadable/link/<link_id>)
+          id_v2 #  introduce new id_v2 field in DownloadableProductLinks (format: downloadable/link/<link_id>)
           #  see \Magento\DownloadableGraphQl\Model\Cart\BuyRequest\DownloadableLinksDataProvider
           title
         }
@@ -107,7 +109,7 @@ query {
           sku
           title
           options {
-            uuid #  introduce new UUID field in BundleItemOption (format: bundle/<option-id>/<option-value-id>/<option-quantity>)
+            id_v2 #  introduce new id_v2 field in BundleItemOption (format: bundle/<option-id>/<option-value-id>/<option-quantity>)
             # see \Magento\BundleGraphQl\Model\Cart\BuyRequest\BundleDataProvider
             id
             label
@@ -115,7 +117,7 @@ query {
         }
       }      ... on GiftCardProduct {
         giftcard_amounts {
-          uuid # introduce new UUID field in GiftCardAmounts (format: giftcard/...TBD)
+          id_v2 # introduce new id_v2 field in GiftCardAmounts (format: giftcard/...TBD)
           # see \Magento\GiftCard\Model\Quote\Item\CartItemProcessor::convertToBuyRequest
           value_id
           website_id


### PR DESCRIPTION
## Problem

We do not have an explicit approach how the client can receive Selected/Eneterd options in order to add the product to cart for a single mutation

<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
Provide details imlementation for Selected, Entered options
Propose to introduce new "uuid: String!" fields in Product Shema to solve the problem

Q/A
We cannot use "id" OR "value_id" os similar due to:
- some types already reserve theses fields, e.g BundleItemOption: (id: Int!), GiftCardProduct(value_id)


<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
