### PR TITLE
magento/architecture#: GraphQl. Add a mutation for subscribe feature

### DIFF
--- a/design-documents/graph-ql/coverage/SubscribeEmailToNewsletter.graphqls
+++ b/design-documents/graph-ql/coverage/SubscribeEmailToNewsletter.graphqls
@@ -1,0 +1,14 @@
+type Mutation {
+    subscribeEmailToNewsletter(email: String!): SubscribeEmailToNewsletterOutput @doc(description:"Adds an email into a newsletter subscription")
+}
+
+type SubscribeEmailToNewsletterOutput {
+    status: SubscriptionStatusesEnum @doc(description: "Returns a status of subscription")
+}
+
+enum SubscriptionStatusesEnum {
+    NOT_ACTIVE
+    SUBSCRIBED
+    UNSUBSCRIBED
+    UNCONFIRMED
+}


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->


There is a subscribe field on a standard Magento storefront:

![27337](https://user-images.githubusercontent.com/13585327/76973533-c0aefd00-6938-11ea-946b-ee17fd924ee6.png)


Currently, GraphQl does not have a mutation which allow to subscribe guest/customer into a newsletter subscription.

## Solution

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

```
type Mutation {
    subscribeEmailToNewsletter(email: String!): SubscribeOutput @doc(description:"Adds an email into a newsletter subscription")
}

type SubscribeOutput {
    status: Int! @doc(description: "Returns a status of subscription")
}
```

`SubscribeOutput`.`status` may return the next statuses:
- [1 - Subscribed](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Newsletter/Model/Subscriber.php#L56)
- [2 - Not Active](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Newsletter/Model/Subscriber.php#L57)

Depends on status the possible messages will be displayed, for example on PWA side:
- [The confirmation request has been sent.](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php#L218) (if `SubscribeOutput`.`status` = [Not Active](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Newsletter/Model/Subscriber.php#L57))
- [Thank you for your subscription.](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php#L221)

**PR:** https://github.com/magento/magento2/pull/27586
**Issue in CORE repo:** https://github.com/magento/magento2/issues/27337

## Requested Reviewers

- @paliarush 

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->

Thank you!
