### PR TITLE
ECP-469: Finalize new search schema

### DIFF
--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -4,7 +4,14 @@
 type Query {
     multiSearch(phrase: String!, productSize: Int = 10): MultiSearchResponse!
     #Filter supports multiple clauses which will be wrapped in logical AND operator
-    productSearch(phrase: String!, filter: [SearchClauseInput], sort: [ProductSearchSortInput]): ProductSearchResponse!
+    productSearch(
+        phrase: String!,
+        "Desired size of the search result page"
+        pageSize: Int = 20,
+        currentPage: Int = 1,
+        filter: [SearchClauseInput],
+        sort: [ProductSearchSortInput]
+    ): ProductSearchResponse!
 }
 
 input ProductSearchSortInput
@@ -15,12 +22,12 @@ input ProductSearchSortInput
 
 # If from or to fields are omitted, $gte or $lte filter will be applied
 input SearchRangeInput {
-    from: Int
-    to: Int
+    from: Float
+    to: Float
 }
 
 input SearchClauseInput {
-    attribute: String!
+    attribute_code: String!
     in: [String]
     eq: String
     range: SearchRangeInput

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -35,6 +35,7 @@ type ProductSearchResponse {
 
 type MultiSearchResponse {
     products: ProductSearchResponse
+    suggestions: [String]
 }
 
 type ProductSearchItem {

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -4,18 +4,17 @@
 type Query {
     multiSearch(phrase: String!, productSize: Int = 10): MultiSearchResponse!
     #Filter supports multiple clauses which will be wrapped in logical AND operator
-    productSearch(phrase: String!, filter: [SearchClauseInput], sort: ProductSearchSortInput): ProductSearchResponse!
+    productSearch(phrase: String!, filter: [SearchClauseInput], sort: [ProductSearchSortInput]): ProductSearchResponse!
 }
 
 input ProductSearchSortInput
 {
-    relevance: SortEnum
-    position: SortEnum
-    name: SortEnum
+    attribute: String!
+    direction: SortEnum
 }
 
 # If from or to fields are omitted, $gte or $lte filter will be applied
-type SearchRangeInput {
+input SearchRangeInput {
     from: Int
     to: Int
 }

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -52,7 +52,6 @@ type Highlight {
 interface Bucket {
     #Human readable bucket title
     title: String!
-    attribute: String!
 }
 
 type StatsBucket implements Bucket {
@@ -73,7 +72,7 @@ type RangeBucket implements Bucket {
 }
 
 interface Aggregation {
-    name: String!
+    attribute_code: String!
     buckets: [Bucket]!
 }
 ```

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -2,7 +2,6 @@
 
 ```graphql
 type Query {
-    multiSearch(phrase: String!, productSize: Int = 10): MultiSearchResponse!
     #Filter supports multiple clauses which will be wrapped in logical AND operator
     productSearch(
         phrase: String!,
@@ -41,11 +40,6 @@ type ProductSearchResponse {
     related_terms: [String]
     page_info: SearchResultPageInfo
     total_count: Int
-}
-
-type MultiSearchResponse {
-    products: ProductSearchResponse
-    suggestions: [String]
 }
 
 type ProductSearchItem {

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -52,16 +52,16 @@ type Highlight {
 interface Bucket {
     #Human readable bucket title
     title: String!
+    attribute: String!
 }
 
 type StatsBucket implements Bucket {
-    #Could be used for filtering and may contain non-human readable data
-    id: ID!
     min: Int!
     max: Int!
 }
 
 type ScalarBucket implements Bucket {
+    #Could be used for filtering and may contain non-human readable data
     id: ID!
     count: Int!
 }

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -4,7 +4,7 @@
 type Query {
     multiSearch(phrase: String!, productSize: Int = 10): MultiSearchResponse!
     #Filter supports multiple clauses which will be wrapped in logical AND operator
-    productSearch(phrase: String!, filter: [Clause], sort: ProductSearchSortInput): ProductSearchResponse!
+    productSearch(phrase: String!, filter: [SearchClauseInput], sort: ProductSearchSortInput): ProductSearchResponse!
 }
 
 input ProductSearchSortInput
@@ -14,10 +14,17 @@ input ProductSearchSortInput
     name: SortEnum
 }
 
-input Clause {
+# If from or to fields are omitted, $gte or $lte filter will be applied
+type SearchRangeInput {
+    from: Int
+    to: Int
+}
+
+input SearchClauseInput {
     attribute: String!
     in: [String]
     eq: String
+    range: SearchRangeInput
 }
 
 type ProductSearchResponse {
@@ -42,21 +49,31 @@ type Highlight {
     matchedWords: [String]!
 }
 
-interface Aggregation {
-    name: String!
-    buckets: [Bucket]!
+interface Bucket {
+    #Human readable bucket title
+    title: String!
 }
 
-interface Bucket {
-    count: Int!
+type StatsBucket implements Bucket {
+    #Could be used for filtering and may contain non-human readable data
+    id: ID!
+    min: Int!
+    max: Int!
 }
 
 type ScalarBucket implements Bucket {
-    title: String!
+    id: ID!
+    count: Int!
 }
 
 type RangeBucket implements Bucket {
     from: Float!
     to: Float!
+    count: Int!
+}
+
+interface Aggregation {
+    name: String!
+    buckets: [Bucket]!
 }
 ```

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -1,0 +1,62 @@
+# Queries
+
+```graphql
+type Query {
+    multiSearch(phrase: String!, productSize: Int = 10): MultiSearchResponse!
+    #Filter supports multiple clauses which will be wrapped in logical AND operator
+    productSearch(phrase: String!, filter: [Clause], sort: ProductSearchSortInput): ProductSearchResponse!
+}
+
+input ProductSearchSortInput
+{
+    relevance: SortEnum
+    position: SortEnum
+    name: SortEnum
+}
+
+input Clause {
+    attribute: String!
+    in: [String]
+    eq: String
+}
+
+type ProductSearchResponse {
+    items: [ProductSearchItem]
+    hits: Int!
+    facets: [Aggregation]
+    facetsValues: [Aggregation]
+}
+
+type MultiSearchResponse {
+    products: ProductSearchResponse
+}
+
+type ProductSearchItem {
+    product: ProductInterface!
+    highlights: [Highlight]
+}
+
+type Highlight {
+    attribute: String!
+    value: String!
+    matchedWords: [String]!
+}
+
+interface Aggregation {
+    name: String!
+    buckets: [Bucket]!
+}
+
+interface Bucket {
+    count: Int!
+}
+
+type ScalarBucket implements Bucket {
+    title: String!
+}
+
+type RangeBucket implements Bucket {
+    from: Float!
+    to: Float!
+}
+```

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -38,6 +38,7 @@ type ProductSearchResponse {
     hits: Int!
     facets: [Aggregation]
     facets_values: [Aggregation]
+    suggestions: [String]
 }
 
 type MultiSearchResponse {

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -10,7 +10,7 @@ type Query {
 input ProductSearchSortInput
 {
     attribute: String!
-    direction: SortEnum
+    direction: SortEnum!
 }
 
 # If from or to fields are omitted, $gte or $lte filter will be applied

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -30,7 +30,7 @@ type ProductSearchResponse {
     items: [ProductSearchItem]
     hits: Int!
     facets: [Aggregation]
-    facetsValues: [Aggregation]
+    facets_values: [Aggregation]
 }
 
 type MultiSearchResponse {
@@ -46,7 +46,7 @@ type ProductSearchItem {
 type Highlight {
     attribute: String!
     value: String!
-    matchedWords: [String]!
+    matched_words: [String]!
 }
 
 interface Bucket {

--- a/design-documents/graph-ql/coverage/search.md
+++ b/design-documents/graph-ql/coverage/search.md
@@ -35,10 +35,12 @@ input SearchClauseInput {
 
 type ProductSearchResponse {
     items: [ProductSearchItem]
-    hits: Int!
     facets: [Aggregation]
     facets_values: [Aggregation]
     suggestions: [String]
+    related_terms: [String]
+    page_info: SearchResultPageInfo
+    total_count: Int
 }
 
 type MultiSearchResponse {
@@ -63,8 +65,8 @@ interface Bucket {
 }
 
 type StatsBucket implements Bucket {
-    min: Int!
-    max: Int!
+    min: Float!
+    max: Float!
 }
 
 type ScalarBucket implements Bucket {


### PR DESCRIPTION
# Overview

This PR contains graphql schema changes required to introduce new search functionality such as 
* highlights - parts of product attribute values which contain matched words. The words might be slightly different compared to the input, so they can't be calculated on the client side.
* multi-facets - possibility to check multiple values per facet. This means that in addition to filtered results we need to get the facets without any filters. 
* advanced range facets (prices) - support of slider UX element. Basically, we need to extract additional information about price ranges, like min value; max value, etc.
* suggestions, "did you mean?", etc  - not a part of the proposed schema, but we need to make sure these parts are fit well in the future.
* preselected variations - most relevant variation is preselected and rendered instead of configurable

The main challenge is to find a proper place in existing/new queries for new fields. 

# Inject into one of the existing types/queries

## `products` query
```graphql
type Query {
    products (
        search: String,
        filter: ProductAttributeFilterInput,
        pageSize: Int = 20,
        currentPage: Int = 1,
        sort: ProductAttributeSortInput
    ): Products
}
type Products {
    items: [ProductInterface]
    page_info: SearchResultPageInfo
    total_count: Int
    filters: [LayerFilter]
    aggregations: [Aggregation]
    sort_fields: SortFields
}
```

`products` query covers two main use cases: search by search phrase and catalog browsing with filtering by category.
This query is the most obvious choice for search-related customizations.
However, this query returns a `Products` type with `ProductInterface` inside. The `ProductInterface` is designed to
represent a product entity with complex product types support.

Adding fields to `ProductInterface` or `Products` will
make those fields optional and useless in "catalog browsing" scenario. Other words, our query is handling two different
use cases with two different results. Mixing those results in very common `ProductInterface` is messy,
inconvenient and just strange.

`Products` type is a little bit better place for new fields. We can put request-specific fields here, but we also need to introduce one more items conainer for
search results(will contain highlights + products). This approach is still messy, but at least it doesn't affect other product usecases (shopping cart item, wishlist item, pdp, etc).
Example for this option:
```graphql
type Query {
    products (
        search: String,
        filter: ProductAttributeFilterInput,
        pageSize: Int = 20,
        currentPage: Int = 1,
        sort: ProductAttributeSortInput
    ): Products
}
type Products {
    items: [ProductInterface] @deprecated(???????)
    search_items: [ProductSearchItem]
    suggestions: [String]
    page_info: SearchResultPageInfo
    total_count: Int
    filters: [LayerFilter]
    aggregations: [Aggregation]
    sort_fields: SortFields
}
type ProductSearchItem {
    product: ProductInterface!
    highlights: [HighlightType]
}
```

## other queries with product results
There are two more queries which return products and could be considered as a potential candidate for new fields:
category and categoryList. Both return `CategoryInterface` interface with `products` field inside:
```graphql
interface CategoryInterface
    id: Int
    ...
    default_sort_by: String 
    products(
        pageSize: Int = 20 
        currentPage: Int = 1 
        sort: ProductAttributeSortInput 
    ): CategoryProducts 
    breadcrumbs: [Breadcrumb] 
}

type CategoryProducts 
    items: [ProductInterface] 
    page_info: SearchResultPageInfo 
    total_count: Int 
}

```

This interface also returns `ProductInterface` and also those queries do not receive a search phrase. Thus it's they are not a good candidates for new search functionality.


# Proper place
In order to find the proper place we may take a look on the use cases we have and want to support:

* Browsing by category - includes layered navigation (facets). Supports further filtering.
* Searching by phrase - includes layered navigation (facets). Supports further filtering. Additional ordering by relevancy, highlights, variation preselect, suggestions
* Advanced search - filtering by some values & full-text search by another
* Product details page
* Various product representation - wishlist item, shopping cart item
* Category navigation

I think the following table is the desired assigment of queries per use cases:

| Scenario | Current Query | Suggested Query | Required changes |
| ------------- | ---- | ---- | ---- |
| Browsing by category | products<br/>category<br/>categoryList | category | Add layered navigation results<br/>Add filters to product sub-request |
| Searching by phrase  | products | new query | deprecate search related fields in `products` query |
| Advanced search      | n/a | TBD | TBD<br/>Probably can be omitted |
| PDP                  | products | products | deprecate filtering except product id |
| Category Navigation  | categoryList | categoryList | deprecate all non-category fields |

You can find a possible shape of new query in PR content.

From the table above we can see that `products` query will be used mostly for retrieving the product by their ids, other functionality will be transferred to `productSearch` query.
Thus we may also deprecate entire `products` query entirely and create a new query designed to get products by ids.

Here is a possible shape of the api if we decide to deprecated old query:
```graphql
type Query {
    "This query is deprecated by still works for backwards-compatibilty purposes"
    products (
            search: String,
            filter: ProductAttributeFilterInput,
            pageSize: Int = 20,
            currentPage: Int = 1,
            sort: ProductAttributeSortInput
        ): Products @deprecated("See product or productSearch queries")

     productSearch(
         phrase: String!,
         "Desired size of the search result page"
         pageSize: Int = 20,
         currentPage: Int = 1,
         filter: [SearchClauseInput],
         sort: [ProductSearchSortInput]
     ): ProductSearchResponse!

     product(id: ID!): ProductInterface
}
```


Here are few possible examples per use case:

_Category Listing_
```graphql
category(id: 17) {
    products {
        items {
            id
            name
            sku
            thumbnail {
                url
            }
        }
    }
}
```

_Search by phrase_
```graphql
productSearch(phrase: "Bags") {
    items {
       product {
            id
            name
            sku
            thumbnail {
                url
            }
       }
       hightlights {
           attribute_code
           value
       }
    }
}
```

_Product details page_

```graphql
product(id: 18) {
    id
    name
    sku
    media_gallery_entries {
        url
        media_type
        content
    }
}
```

_Category navigation_
```graphql
categoryList {
    id
    name
    url_path
    children {
        id
        name
        url_path
        children {
            id
            name
            url_path
        }
    }
}
```