### PR TITLE
GraphQL B2B Company schema updates

### DIFF
--- a/design-documents/graph-ql/coverage/company.md
+++ b/design-documents/graph-ql/coverage/company.md
@@ -6,11 +6,11 @@
 
 ```graphql
 type Query {
-    company: Company  @doc(description: "Returns all information about the current Company.")
-    checkCompanyEmail(email: String!): CompanyEmailCheckResponse  @doc(description: "Returns result of validation whether provided email address is valid for a new Company registration or not.")
-    checkCompanyAdminEmail(email: String!): CompanyAdminEmailCheckResponse  @doc(description: "Returns result of validation whether provided email address is valid for a Company Administrator registration or not.")
-    checkCompanyUserEmail(email: String!): CompanyUserEmailCheckResponse  @doc(description: "Returns an object with result of validation whether provided email address is valid for a new Customer - Company User - registration or not.")
-    checkCompanyRoleName(name: String!): CompanyRoleNameCheckResponse  @doc(description: "Returns result of validation whether provided Role name is available.")
+    company: Company  @doc(description: "Company assigned to the currently authenticated user")
+    checkCompanyEmail(email: String!): CompanyEmailCheckResponse  @doc(description: "Check if an email is valid for company registration")
+    checkCompanyAdminEmail(email: String!): CompanyAdminEmailCheckResponse  @doc(description: "Check if an email is valid for company admin registration")
+    checkCompanyUserEmail(email: String!): CompanyUserEmailCheckResponse  @doc(description: "Check if an email is valid for company user registration")
+    checkCompanyRoleName(name: String!): CompanyRoleNameCheckResponse  @doc(description: "Check if a role name is valid for company")
 }
 
 type Company @doc(description: "Company entity output data schema.") {

--- a/design-documents/graph-ql/coverage/company.md
+++ b/design-documents/graph-ql/coverage/company.md
@@ -29,7 +29,7 @@ type Company @doc(description: "Company entity output data schema.") {
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. Defaults to 20."),
         currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1."),
     ): CompanyUsers @doc(description: "Information about the company users.")
-    user(id: ID): Customer @doc(description: "Returns company user for current authenticated Customer or, if id provided, for specific one.")
+    user(id: ID!): Customer @doc(description: "Returns company user by id.")
     roles(
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. Optional. Defaults to 20."),
         currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1."),

--- a/design-documents/graph-ql/coverage/company.md
+++ b/design-documents/graph-ql/coverage/company.md
@@ -91,19 +91,19 @@ type CompanyAclResource @doc(description: "Output data schema for an object with
 }
 
 type CompanyRoleNameCheckResponse @doc(description: "Response object schema for a role name validation query.") {
-    isNameValid: Boolean! @doc(description: "Role name validation result")
+    isNameValid: Boolean @doc(description: "Role name validation result")
 }
 
 type CompanyUserEmailCheckResponse @doc(description: "Response object schema for a Company User email validation query.") {
-    isEmailValid: Boolean! @doc(description: "Email validation result")
+    isEmailValid: Boolean @doc(description: "Email validation result")
 }
 
 type CompanyAdminEmailCheckResponse @doc(description: "Response object schema for a Company Admin email validation query.") {
-    isEmailValid: Boolean! @doc(description: "Email validation result")
+    isEmailValid: Boolean @doc(description: "Email validation result")
 }
 
 type CompanyEmailCheckResponse @doc(description: "Response object schema for a Company email validation query.") {
-    isEmailValid: Boolean! @doc(description: "Email validation result")
+    isEmailValid: Boolean @doc(description: "Email validation result")
 }
 
 type CompanyHierarchyOutput @doc(description: "Response object schema for a Company Hierarchy query.") {


### PR DESCRIPTION
# Changes

1. In `Company.id`, the `id` parameter has been changed to be non-nullable. This query only needs to do one thing well: lookup a company-associated user by ID. The schema already exposes a way to obtain the currently logged in `Customer` in other places.

2. Updated the descriptions of the root `Query` types to be a bit less verbose

3. Removed non-nullability from the "Check" types' response fields. If we add any other fields to those types later, the current field encountering an error would propagate up and infect the whole type. Can always make it non-nullable later without a breaking change