### PR TITLE
Refactor B2B Company Structure query to remove recursive type and add more edges

### DIFF
--- a/design-documents/graph-ql/coverage/company.md
+++ b/design-documents/graph-ql/coverage/company.md
@@ -36,7 +36,10 @@ type Company @doc(description: "Company entity output data schema.") {
     ): CompanyRoles!  @doc(description: "Returns the list of defined roles at Company.")
     role(id: ID!): CompanyRole  @doc(description: "Returns company role by id.")
     acl_resources: [CompanyAclResource]  @doc(description: "Returns the list of all permission resources.")
-    hierarchy: CompanyHierarchyOutput  @doc(description: "Returns the complete data about company structure.")
+    structure(
+        rootID: ID = 0 @doc(description: "Tree depth to begin query")
+        depth: Int = 10 @doc(description: "Specifies how deeply results are fetched")
+    ): CompanyStructure @doc(description: "Company structure of teams and customers in depth-first order")
     team(id: ID!): CompanyTeam  @doc(description: "Returns company team data by id.")
 }
 
@@ -106,19 +109,16 @@ type CompanyEmailCheckResponse @doc(description: "Response object schema for a C
     isEmailValid: Boolean! @doc(description: "Email validation result")
 }
 
-type CompanyHierarchyOutput @doc(description: "Response object schema for a Company Hierarchy query.") {
-    structure: CompanyHierarchyElement @doc(description: "An array of Company structure elements.")
-    isEditable: Boolean @doc(description: "Flag that defines whether Company Hierarchy can be changed by current User or not.")
-    max_nesting: Int @doc(description: "Indicator of maximun nesting of elements within a whole Company Hierarchy.")
+union CompanyStructureEntity = CompanyTeam | Customer
+
+type CompanyStructureItem @doc(description: "Company Team and Customer structure") {
+    id: ID! @doc(description: "ID of the item in the hierarchy")
+    parentID: ID @doc(description: "ID of the parent item in the hierarchy")
+    entity: CompanyStructureEntity
 }
 
-type CompanyHierarchyElement @doc(description: "Company Hierarchy element output data schema.") {
-    id: ID! @doc(description: "Hierarchy element id.")
-    tree_id: ID @doc(description: "The hierarchical id of the element within a structure. Used for changing element's position in hierarchy.")
-    type: String @doc(description: "Hierarchy element type: 'customer' or a 'team'.")
-    text: String @doc(description: "Hierarchy element name.")
-    description: String @doc(description: "Hierarchy element description.")
-    children: [CompanyHierarchyElement!] @doc(description: "An array of child elements.")
+type CompanyStructure {
+    items: CompanyStructureItem[]
 }
 
 type CompanyTeam @doc(description: "Company Team entity output data schema.") {


### PR DESCRIPTION
## Problems

The schema for the [B2B Company Structure](https://docs.magento.com/m2/b2b/user_guide/customers/account-company-structure.html) has a few problems in my opinion:

1. `isEditable` seems out of place. There are other APIs in this company schema that a UI can use to determine if a user has permissions to edit the company structure.

2. The description of the `CompanyHierarchyElement.type` field is `Hierarchy element type: 'customer' or a 'team'`, but is typed as a `String`, meaning the client-side and server-side have implicit shared constants not defined in the schema

3. `CompanyHierarchyElement` does not provide any edges for a query to get access to the `Customer` or `CompanyTeam`. Instead, it decides what the UI has to show via a `text` and `description` field. If more info about the customer/company needs to be shown in the UI, it would require a second round-trip.

4. The `CompanyHierarchyElement` type is infinitely recursive via the `children` property. These are a major pain to query because the client has to dynamically build up a query, and size of the query itself grows with the tree depth. [I brought this up in the original review](https://github.com/magento/architecture/pull/366#discussion_r403141125) but it wasn't quite addressed. This is a design we've already had problems with in practice. See the linked prior discussion for details

5. No support for lazy-loading of large trees. For users on slow connections, the client-side will want the option of fetching only the first level or two of items, then load them in later (either during network idle time or when a user expands the tree).

6. Because of the recursive types, there is no foolproof way to get the entire company structure in one query. The current schema has a `max_depth` field that can be requested, but that would require 1 round trip to get the depth, and then a second once a query with that many levels has been constructed.

7. In our B2B docs we describe this as a `Company Structure`, but the field is named `hierarchy` here, which makes it more difficult to quickly Google for.

## Solutions

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

1. Remove `isEditable` field. Can be added back later if it's deemed necessary

2. Instead of an implicit constant via `CompanyHierarchyElement.type`, we're using a `union`, so the known values are expressed via the type system (introspectable via `__typename`).

3. Instead of `CompanyHierarchyElement.description` and `CompanyHierarchyElement.text`, the `CompanyStructureItem.entity` field will provide access to the `Customer` or `CompanyTeam` types.

4. No more recursive types for company structure

5. Renamed `Company.hierarchy` to `Company.structure`


## Requested Reviewers

- @kokoc
- @paliarush 