### PR TITLE
Change CompanyRole.permissions from [String] to [CompanyAclResource]

### DIFF
--- a/design-documents/graph-ql/coverage/company.md
+++ b/design-documents/graph-ql/coverage/company.md
@@ -80,7 +80,7 @@ type CompanyRole @doc(description: "Company role output data schema returned in 
     id: ID! @doc(description: "Role id.")
     name: String @doc(description: "Role name.")
     users_count: Int @doc(description: "Total number of Users with such Role within Company Hierarchy.")
-    permissions: [String] @doc(description: "A list of permission resources defined for a Role.")
+    permissions: [CompanyAclResource] @doc(description: "A list of permission resources defined for a Role.")
 }
 
 type CompanyAclResource @doc(description: "Output data schema for an object with Role permission resource information.") {


### PR DESCRIPTION
## Problem

When selecting from `CompanyRole.permissions`, you get a `[String]` of permission IDs. A UI may wish to capture the permission's label text in the same request.

## Solution

Change permissions to point to the appropriate type (`CompanyAclResource`)

## Requested Reviewers

@kokoc 
@paliarush 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
