### PR TITLE
b2b requisition list schema

### DIFF
--- a/design-documents/graph-ql/coverage/requisitionList.graphql
+++ b/design-documents/graph-ql/coverage/requisitionList.graphql
@@ -10,7 +10,7 @@ type Customer {
     "Get Requisition Lists of customer"
     requisitionLists(
         pageSize: Int = 20,
-        currentPage:Int = 1
+        currentPage: Int = 1
     ): RequisitionLists
 }
 
@@ -117,7 +117,7 @@ type Mutation {
     "Create Empty Requisition List"
     createRequisitionList(
         "name for the list"
-        name: String!
+        name: String!,
         "description For the list"
         description: String
     ): RequisitionList
@@ -159,9 +159,9 @@ type Mutation {
     "Add Requisition List Items To Cart"
     addRequisitionListItemToCart(
         "Cart Id to which requisition list needs to copied"
-        cart_id: String!
+        cart_id: String!,
         "unique Id of requisition list"
-        requisition_list_id: ID!
+        requisition_list_id: ID!,
         "selected requisition list items that are to be added"
         item_ids: [ID!]!
     ): AddRequisitionListItemToCartOutput
@@ -169,9 +169,9 @@ type Mutation {
     "Copy Items from Requisition List"
     copyItemsFromRequisitionList(
         "unique Id of source requisition list"
-        source_id: ID!
+        source_id: ID!,
         "unique Id of destination requisition list"
-        destination_id: ID # If null new requisition list will be created
+        destination_id: ID, # If null new requisition list will be created
         "selected requisition list items that are to be copied from source"
         item_ids: [ID!]!
     ): CopyItemsFromRequisitionListOutput
@@ -179,9 +179,9 @@ type Mutation {
     "Move Items from Requisition List"
     moveItemsFromRequisitionList(
         "unique Id of source requisition list"
-        source_id: ID!
+        source_id: ID!,
         "unique Id of destination requisition list"
-        destination_id: ID # If null new requisition list will be created
+        destination_id: ID, # If null new requisition list will be created
         "selected requisition list items that are to be moved from source"
         item_ids: [ID!]!
     ): MoveItemsFromRequisitionListOutput

--- a/design-documents/graph-ql/coverage/requisitionList.graphql
+++ b/design-documents/graph-ql/coverage/requisitionList.graphql
@@ -1,0 +1,248 @@
+## Gift Card product type support will be added after the Product Implementation is developed
+type Query {
+    "The requisitionList query returns the contents of customer's  Requisition List"
+    requisitionList(
+        id: ID!
+    ): RequisitionList
+}
+
+type Customer {
+    "Get Requisition Lists of customer"
+    requisitionLists(
+        pageSize: Int = 20,
+        currentPage:Int = 1
+    ): RequisitionLists
+}
+
+"Provides Requisition Lists of customer"
+type RequisitionLists  {
+    "List of Requisition Lists"
+    items: [RequisitionList]
+    "Page Information for pagination"
+    page_info: PageInfo
+    "Total count of Requisition Lists"
+    total_count: Int
+}
+
+"Requisition List Type"
+type RequisitionList {
+    "Unique Identifier of Requisition List"
+    id: ID!
+    "Name of the list"
+    name: String!
+    "Description of the list"
+    description: String
+    "Items in the list"
+    items: [RequisitionListItemInterface]
+    "Number of items in list"
+    items_count: Int!
+    "Latest Activity"
+    updated_at: String
+}
+
+"Interface type for Requisition List Item"
+interface RequisitionListItemInterface {
+    "Unique Identifier of Requisition List Item"
+    id: ID!
+    "Product"
+    product: ProductInterface!
+    "Quantity added"
+    qty: Float!
+}
+
+type SimpleRequisitionListItem implements RequisitionListItemInterface {
+    "Unique Identifier of Requisition List Item"
+    id: ID!
+    "Product"
+    product: ProductInterface!
+    "Quantity added"
+    qty: Float!
+    "custom Option selected"
+    customizable_options: [SelectedCustomizableOption]
+}
+
+type VirtualRequisitionListItem implements RequisitionListItemInterface {
+    "Unique Identifier of Requisition List Item"
+    id: ID!
+    "Product"
+    product: ProductInterface!
+    "Quantity added"
+    qty: Float!
+    "custom Option selected"
+    customizable_options: [SelectedCustomizableOption]
+}
+
+type DownloadableRequisitionListItem implements RequisitionListItemInterface {
+    "Unique Identifier of Requisition List Item"
+    id: ID!
+    "Product"
+    product: ProductInterface!
+    "Quantity added"
+    qty: Float!
+    "custom Option selected"
+    customizable_options: [SelectedCustomizableOption]
+    "DownloadableProductLinks defines characteristics of a downloadable product"
+    links: [DownloadableProductLinks]
+    "DownloadableProductSamples defines characteristics of a downloadable product"
+    samples: [DownloadableProductSamples]
+}
+
+type BundleRequisitionListItem implements RequisitionListItemInterface {
+    "Unique Identifier of Requisition List Item"
+    id: ID!
+    "Product"
+    product: ProductInterface!
+    "Quantity added"
+    qty: Float!
+    "custom Option selected"
+    customizable_options: [SelectedCustomizableOption]
+    "selected bundle options"
+    bundle_options: [SelectedBundleOption]!
+}
+
+type ConfigurableRequisitionListItem implements RequisitionListItemInterface {
+    "Unique Identifier of Requisition List Item"
+    id: ID!
+    "Product"
+    product: ProductInterface!
+    "Quantity added"
+    qty: Float!
+    "custom Option selected"
+    customizable_options: [SelectedCustomizableOption]
+    "Configurable options selected"
+    configurable_options: [SelectedConfigurableOption]
+}
+
+type Mutation {
+    "Create Empty Requisition List"
+    createRequisitionList(
+        "name for the list"
+        name: String!
+        "description For the list"
+        description: String
+    ): RequisitionList
+
+    "Rename a requisition list"
+    renameRequisitionList(
+        "unique Id of requisition list"
+        id: ID!,
+        "new name for list"
+        name: String,
+        "new description For the List"
+        description: String
+    ): RequisitionList
+
+    "Add items to requisition list"
+    addProductsToRequisitionList(
+        "unique Id of requisition list"
+        id: ID!,
+        "Products to be added to requisition list"
+        items: [RequisitionListItemsInput!]!
+    ): AddProductsToRequisitionListOutput
+
+    "Remove Items in requisition list"
+    removeRequisitionListItems(
+        "unique Id of requisition list"
+        id: ID!,
+        "unique Ids of Items to be removed from requisition list"
+        items: [ID!]!
+    ): RemoveRequisitionListItemsOutput
+
+    "Update Items in requisition list"
+    updateRequisitionListItems(
+        "unique Id of requisition list"
+        id: ID!,
+        "Items to be updated from requisition list"
+        items: [UpdateRequisitionListItemsInput!]!
+    ): UpdateRequisitionListItemsOutput
+
+    "Add Requisition List Items To Cart"
+    addRequisitionListItemToCart(
+        "Cart Id to which requisition list needs to copied"
+        cart_id: String!
+        "unique Id of requisition list"
+        requisition_list_id: ID!
+        "selected requisition list items that are to be added"
+        item_ids: [ID!]!
+    ): AddRequisitionListItemToCartOutput
+
+    "Copy Items from Requisition List"
+    copyItemsFromRequisitionList(
+        "unique Id of source requisition list"
+        source_id: ID!
+        "unique Id of destination requisition list"
+        destination_id: ID # If null new requisition list will be created
+        "selected requisition list items that are to be copied from source"
+        item_ids: [ID!]!
+    ): CopyItemsFromRequisitionListOutput
+
+    "Move Items from Requisition List"
+    moveItemsFromRequisitionList(
+        "unique Id of source requisition list"
+        source_id: ID!
+        "unique Id of destination requisition list"
+        destination_id: ID # If null new requisition list will be created
+        "selected requisition list items that are to be moved from source"
+        item_ids: [ID!]!
+    ): MoveItemsFromRequisitionListOutput
+}
+
+type RemoveRequisitionListItemsOutput {
+    requisition_list : RequisitionList
+}
+
+type UpdateRequisitionListItemsOutput {
+    requisition_list : RequisitionList
+}
+
+type AddProductsToRequisitionListOutput {
+    requisition_list : RequisitionList
+}
+
+input RequisitionListItemsInput {
+    sku: String!
+    quantity: Float
+    parent_sku: String
+    "selected option ID"
+    selected_options: [String!]
+    "entered Options ID"
+    entered_options: [EnteredOptionInput!]
+}
+
+input UpdateRequisitionListItemsInput {
+    "unique ID of Requisition List Item"
+    item_id: ID!
+    customizable_options: [CustomizableOptionInput]
+    quantity: Float
+}
+
+type AddRequisitionListItemToCartOutput {
+    cart: Cart # since requisition list is not mutated it is not part of the output
+}
+
+type CopyItemsFromRequisitionListOutput {
+    "Destination Requisition List"
+    list : RequisitionList # since source requisition list is not mutated it is not part of the output
+}
+
+type MoveItemsFromRequisitionListOutput {
+    "Source Requisition List"
+    source : RequisitionList
+    "Destination Requisition List"
+    destination : RequisitionList
+}
+
+input EnteredOptionInput {
+    id: String!
+    value: String!
+}
+
+"PageInfo provides navigation for the query response"
+type PageInfo {
+    "Specifies which page of results to return"
+    current_page: Int
+    "Specifies the maximum number of items to return"
+    page_size: Int
+    "Total pages"
+    total_pages: Int
+}

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -1,11 +1,34 @@
-## Gift Card product type support will be added after the Product Implementation is developed
-type Query {
-    "The requisitionList query returns the contents of customer's  Requisition List"
-    requisitionList(
-        id: ID!
-    ): RequisitionList
+# Requistion List Flow User Flow
+#
+# 1.1. Create a requistion List at Customer's My Account section using `createRequistionList` Mutation
+#
+# 1.2. From catalog pages search for products and add products to already available list with `addProductsToRequisitionList`
+#  mutation or create a list with `createRequistionList` and on success add products with `addProductsToRequisitionList`
+#
+# 1.3. Select a requistion list from My Account and  customer query `requisitionLists` with id filter will fetch requistion
+# list details
+#
+# 1.4 Select a list of items from the requisition List and perform `addRequisitionListItemToCart`, so the items are copied
+# to cart
+#
+# 1.5 perform regular checkout flow
+#
+# 2. In requistion list view, `exportRequisitionList` query will generate a CSV file with particular requistion list data
+#
+# 3. In requistion list view, `renameRequistionList` mutatation can be used to rename the list
+#
+# 4. In requistion list view, one can edit items quantity, options etc or remove items with `removeRequisitionListItems` and
+# `updateRequisitionListItems` mutation
+#
+# 5. In requistion list view, select requistion list items and move them , copy them to different requistion list with
+# `moveItemsFromRequisitionList` and `copyItemsFromRequisitionList` mutations respectively
+#
 
-    "Export Requisition list"
+
+type Query {
+    """
+    Export Requisition list in Csv format
+    """
     exportRequisitionList(
         "unqiue Id of Requisition list"
         id: ID!
@@ -16,21 +39,26 @@ type Customer {
     "Get Requisition Lists of customer"
     requisitionLists(
         pageSize: Int = 20,
-        currentPage: Int = 1
+        currentPage: Int = 1,
+        filter: RequisitionListFilterInput
     ): RequisitionLists
 }
 
-"Provides Requisition Lists of customer"
+"""
+Provides Customer's Requisition Lists
+"""
 type RequisitionLists  {
     "List of Requisition Lists"
     items: [RequisitionList]
     "Page Information for pagination"
-    page_info: PageInfo
+    page_info: SearchResultPageInfo
     "Total count of Requisition Lists"
     total_count: Int
 }
 
-"Requisition List Type"
+"""
+Requisition List Type
+"""
 type RequisitionList {
     "Unique Identifier of Requisition List"
     id: ID!
@@ -46,17 +74,21 @@ type RequisitionList {
     updated_at: String
 }
 
-"Interface type for Requisition List Item"
+"""
+Interface type for Requisition List Item
+"""
 interface RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
-    "Product"
     product: ProductInterface!
     "Quantity added"
     qty: Float!
 }
 
-type SimpleRequisitionListItem implements RequisitionListItemInterface {
+"""
+Requisition List Item Implementation that for Simple and Virtual Products
+"""
+type DefaultRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
     "Product"
@@ -67,21 +99,12 @@ type SimpleRequisitionListItem implements RequisitionListItemInterface {
     customizable_options: [SelectedCustomizableOption]
 }
 
-type VirtualRequisitionListItem implements RequisitionListItemInterface {
-    "Unique Identifier of Requisition List Item"
-    id: ID!
-    "Product"
-    product: ProductInterface!
-    "Quantity added"
-    qty: Float!
-    "custom Option selected"
-    customizable_options: [SelectedCustomizableOption]
-}
-
+"""
+Requisition List Item Implementation that for Downloadable Products
+"""
 type DownloadableRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
-    "Product"
     product: ProductInterface!
     "Quantity added"
     qty: Float!
@@ -93,6 +116,9 @@ type DownloadableRequisitionListItem implements RequisitionListItemInterface {
     samples: [DownloadableProductSamples]
 }
 
+"""
+Requisition List Item Implementation that for Bundle Products
+"""
 type BundleRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
@@ -106,6 +132,9 @@ type BundleRequisitionListItem implements RequisitionListItemInterface {
     bundle_options: [SelectedBundleOption]!
 }
 
+"""
+Requisition List Item Implementation that for Configurable Products
+"""
 type ConfigurableRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
@@ -120,30 +149,40 @@ type ConfigurableRequisitionListItem implements RequisitionListItemInterface {
 }
 
 type Mutation {
-    "Create Empty Requisition List"
+
+    """
+    Create Empty Requisition List
+    """
     createRequisitionList(
         "name for the list"
         name: String!,
         "description For the list"
         description: String
-    ): RequisitionList
+    ): CreateRequisitionListOutput
 
-    "Rename a requisition list"
+    """
+    Rename a requisition list and change description"
+    """
     renameRequisitionList(
         "unique Id of requisition list"
         id: ID!,
         "new name for list"
         name: String!,
         "new description For the List"
-        description: String!
-    ): RequisitionList
+        description: String
+    ): RenameRequisitionListOutput
 
-    DeleteRequisitionList(
+    """
+    Delete a requisition list with Id
+    """
+    deleteRequisitionList(
         "unique Id of requisition list"
         id: ID!
-    ): RequisitionList
+    ): Boolean
 
-    "Add items to requisition list"
+    """
+    Add items to requisition list
+    """
     addProductsToRequisitionList(
         "unique Id of requisition list"
         id: ID!,
@@ -151,7 +190,9 @@ type Mutation {
         items: [RequisitionListItemsInput!]!
     ): AddProductsToRequisitionListOutput
 
-    "Remove Items in requisition list"
+    """
+    Remove Items in requisition list
+    """
     removeRequisitionListItems(
         "unique Id of requisition list"
         id: ID!,
@@ -159,7 +200,9 @@ type Mutation {
         items: [ID!]!
     ): RemoveRequisitionListItemsOutput
 
-    "Update Items in requisition list"
+    """
+    Update Items in requisition list"
+    """
     updateRequisitionListItems(
         "unique Id of requisition list"
         id: ID!,
@@ -167,17 +210,19 @@ type Mutation {
         items: [UpdateRequisitionListItemsInput!]!
     ): UpdateRequisitionListItemsOutput
 
-    "Add Requisition List Items To Cart"
+    """
+    Add Requisition List Items To Customer Cart"
+    """
     addRequisitionListItemToCart(
-        "Cart Id to which requisition list needs to copied"
-        cart_id: String!,
         "unique Id of requisition list"
         requisition_list_id: ID!,
         "selected requisition list items that are to be added"
         item_ids: [ID!]!
     ): AddRequisitionListItemToCartOutput
 
-    "Copy Items from Requisition List"
+    """
+    Copy Items from Requisition List to another requisition list"
+    """
     copyItemsFromRequisitionList(
         "unique Id of source requisition list"
         source_id: ID!,
@@ -187,7 +232,9 @@ type Mutation {
         item_ids: [ID!]!
     ): CopyItemsFromRequisitionListOutput
 
-    "Move Items from Requisition List"
+    """
+    Move Items from Requisition List to another requisition List
+    """
     moveItemsFromRequisitionList(
         "unique Id of source requisition list"
         source_id: ID!,
@@ -217,6 +264,13 @@ type CsvOutput {
     csv_data: String!
 }
 
+input RequisitionListFilterInput {
+    "Filter Customer Requisition lists with an requisition list ID or list of requisition list IDs"
+    ids: FilterEqualTypeInput,
+    "Filter by display name of the Requisition list"
+    name: FilterMatchTypeInput
+}
+
 input RequisitionListItemsInput {
     sku: String!
     quantity: Float
@@ -234,6 +288,14 @@ input UpdateRequisitionListItemsInput {
     quantity: Float
 }
 
+type CreateRequisitionListOutput {
+    list: RequisitionList
+}
+
+type RenameRequisitionListOutput {
+    list: RequisitionList
+}
+
 type AddRequisitionListItemToCartOutput {
     cart: Cart # since requisition list is not mutated it is not part of the output
 }
@@ -248,14 +310,4 @@ type MoveItemsFromRequisitionListOutput {
     source : RequisitionList
     "Destination Requisition List"
     destination : RequisitionList
-}
-
-"PageInfo provides navigation for the query response"
-type PageInfo {
-    "Specifies which page of results to return"
-    current_page: Int
-    "Specifies the maximum number of items to return"
-    page_size: Int
-    "Total pages"
-    total_pages: Int
 }

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -4,6 +4,12 @@ type Query {
     requisitionList(
         id: ID!
     ): RequisitionList
+
+    "Export Requisition list"
+    exportRequisitionList(
+        "unqiue Id of Requisition list"
+        id: ID!
+    ): CsvOutput
 }
 
 type Customer {
@@ -127,9 +133,14 @@ type Mutation {
         "unique Id of requisition list"
         id: ID!,
         "new name for list"
-        name: String,
+        name: String!,
         "new description For the List"
-        description: String
+        description: String!
+    ): RequisitionList
+
+    DeleteRequisitionList(
+        "unique Id of requisition list"
+        id: ID!
     ): RequisitionList
 
     "Add items to requisition list"
@@ -199,6 +210,13 @@ type AddProductsToRequisitionListOutput {
     requisition_list : RequisitionList
 }
 
+type CsvOutput {
+    "file name"
+    file_name: String
+    "data for csv file with headers and records"
+    data: String
+}
+
 input RequisitionListItemsInput {
     sku: String!
     quantity: Float
@@ -230,11 +248,6 @@ type MoveItemsFromRequisitionListOutput {
     source : RequisitionList
     "Destination Requisition List"
     destination : RequisitionList
-}
-
-input EnteredOptionInput {
-    id: String!
-    value: String!
 }
 
 "PageInfo provides navigation for the query response"

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -25,210 +25,117 @@
 #
 
 type Customer {
-    "Get Requisition Lists of customer"
     requisitionLists(
         pageSize: Int = 20,
         currentPage: Int = 1,
         filter: RequisitionListFilterInput
-    ): RequisitionLists
+    ): RequisitionLists @doc(description: "Get Requisition Lists of customer")
 }
 
-"""
-Provides Customer's Requisition Lists
-"""
-type RequisitionLists  {
-    "List of Requisition Lists"
-    items: [RequisitionList]
-    "Page Information for pagination"
-    page_info: SearchResultPageInfo
-    "Total count of Requisition Lists"
-    total_count: Int
+type RequisitionLists @doc(description: "Provides Customer's Requisition Lists")  {
+    items: [RequisitionList] @doc(description: "List of Requisition Lists")
+    page_info: SearchResultPageInfo @doc(description: "Page Information for pagination")
+    total_count: Int @doc(description: "Total count of Requisition Lists")
 }
 
-"""
-Requisition List Type
-"""
-type RequisitionList {
-    "Unique Identifier of Requisition List"
-    id: ID!
-    "Name of the list"
-    name: String!
-    "Description of the list"
-    description: String
-    "Items in the list"
-    items: [RequisitionListItemInterface]
-    "Number of items in list"
-    items_count: Int!
-    "Latest Activity"
-    updated_at: String
+type RequisitionList @doc(description: "Requisition List Type") {
+    id: ID! @doc(description: "Unique Identifier of Requisition List")
+    name: String! @doc(description: "Name of the list")
+    description: String @doc(description: "Description of the list")
+    items: [RequisitionListItemInterface] @doc(description: "Items in the list")
+    items_count: Int! @doc(description: "Number of items in list")
+    updated_at: String @doc(description: "Latest Activity")
 }
 
-"""
-Interface type for Requisition List Item
-"""
-interface RequisitionListItemInterface {
-    "Unique Identifier of Requisition List Item"
-    id: ID!
+interface RequisitionListItemInterface @doc(description: "Interface type for Requisition List Item") {
+    id: ID! @doc(description:"Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    "Quantity added"
-    qty: Float!
+    qty: Float! @doc(description: "Quantity added")
 }
 
-"""
-Requisition List Item Implementation that for Simple and Virtual Products
-"""
-type DefaultRequisitionListItem implements RequisitionListItemInterface {
-    "Unique Identifier of Requisition List Item"
-    id: ID!
+type DefaultRequisitionListItem implements RequisitionListItemInterface
+@doc(description: "Requisition List Item Implementation that for Simple and Virtual Products") {
+    id: ID! @doc(description: "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    "Quantity added"
-    qty: Float!
-    "custom Option selected"
-    customizable_options: [SelectedCustomizableOption]
+    qty: Float! @doc(description:  "Quantity added")
+    customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
 }
 
-"""
-Requisition List Item Implementation that for Downloadable Products
-"""
-type DownloadableRequisitionListItem implements RequisitionListItemInterface {
-    "Unique Identifier of Requisition List Item"
-    id: ID!
+type DownloadableRequisitionListItem implements RequisitionListItemInterface
+@doc(description: "Requisition List Item Implementation that for Downloadable Products") {
+    id: ID! @doc(description: "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    "Quantity added"
-    qty: Float!
-    "custom Option selected"
-    customizable_options: [SelectedCustomizableOption]
-    "DownloadableProductLinks defines characteristics of a downloadable product"
-    links: [DownloadableProductLinks]
-    "DownloadableProductSamples defines characteristics of a downloadable product"
-    samples: [DownloadableProductSamples]
+    qty: Float! @doc(description: "Quantity added")
+    customizable_options: [SelectedCustomizableOption] @doc(description:  "custom Option selected")
+    links: [DownloadableProductLinks] @doc(description: "DownloadableProductLinks defines characteristics of a downloadable product")
+    samples: [DownloadableProductSamples] @doc(description:  "DownloadableProductSamples defines characteristics of a downloadable product")
 }
 
-"""
-Requisition List Item Implementation that for Bundle Products
-"""
-type BundleRequisitionListItem implements RequisitionListItemInterface {
-    "Unique Identifier of Requisition List Item"
-    id: ID!
+type BundleRequisitionListItem implements RequisitionListItemInterface
+@doc(description: "Requisition List Item Implementation that for Bundle Products") {
+    id: ID! @doc(description: "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    "Quantity added"
-    qty: Float!
-    "custom Option selected"
-    customizable_options: [SelectedCustomizableOption]
-    "selected bundle options"
-    bundle_options: [SelectedBundleOption]!
+    qty: Float! @doc(description: "Quantity added")
+    customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
+    bundle_options: [SelectedBundleOption]! @doc(description: "selected bundle options")
 }
 
-"""
-Requisition List Item Implementation that for Configurable Products
-"""
-type ConfigurableRequisitionListItem implements RequisitionListItemInterface {
-    "Unique Identifier of Requisition List Item"
-    id: ID!
+type ConfigurableRequisitionListItem implements RequisitionListItemInterface
+@doc(description: "Requisition List Item Implementation that for Configurable Products") {
+    id: ID! @doc(description:  "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    "Quantity added"
-    qty: Float!
-    "custom Option selected"
-    customizable_options: [SelectedCustomizableOption]
-    "Configurable options selected"
-    configurable_options: [SelectedConfigurableOption]
+    qty: Float! @doc(description: "Quantity added")
+    customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
+    configurable_options: [SelectedConfigurableOption] @doc(description: "Configurable options selected")
 }
 
 type Mutation {
-
-    """
-    Create Empty Requisition List
-    """
     createRequisitionList(
-        "name for the list"
-        name: String!,
-        "description For the list"
-        description: String
-    ): CreateRequisitionListOutput
+        name: String!, @doc(description: "name for the list")
+        description: String @doc(description: "description For the list")
+    ): CreateRequisitionListOutput @doc(description: "Create Empty Requisition List")
 
-    """
-    Rename a requisition list and change description"
-    """
     renameRequisitionList(
-        "unique Id of requisition list"
-        id: ID!,
-        "new name for list"
-        name: String!,
-        "new description For the List"
-        description: String
-    ): RenameRequisitionListOutput
+        id: ID!, @doc(description: "unique Id of requisition list")
+        name: String!, @doc(description: "new name for list")
+        description: String @doc(description: "new description For the List")
+    ): RenameRequisitionListOutput @doc(description: "Rename a requisition list and change description")
 
-    """
-    Delete a requisition list with Id
-    """
     deleteRequisitionList(
-        "unique Id of requisition list"
-        id: ID!
-    ): DeleteRequisitionListOutput
+        id: ID! @doc(description: "unique Id of requisition list")
+    ): DeleteRequisitionListOutput @doc(description: "Delete a requisition list with Id")
 
-    """
-    Add items to requisition list
-    """
     addProductsToRequisitionList(
-        "unique Id of requisition list"
-        id: ID!,
-        "Products to be added to requisition list"
-        items: [RequisitionListItemsInput!]!
-    ): AddProductsToRequisitionListOutput
+        id: ID!, @doc(description: "unique Id of requisition list")
+        items: [RequisitionListItemsInput!]! @doc(description: "Products to be added to requisition list")
+    ): AddProductsToRequisitionListOutput @doc(description: "Add items to requisition list")
 
-    """
-    Remove Items in requisition list
-    """
     removeRequisitionListItems(
-        "unique Id of requisition list"
-        id: ID!,
-        "unique Ids of Items to be removed from requisition list"
-        items: [ID!]!
-    ): RemoveRequisitionListItemsOutput
+        id: ID!, @doc(description: "unique Id of requisition list")
+        items: [ID!]! @doc(description: "unique Ids of Items to be removed from requisition list")
+    ): RemoveRequisitionListItemsOutput @doc(description: "Remove Items in requisition list")
 
-    """
-    Update Items in requisition list"
-    """
     updateRequisitionListItems(
-        "unique Id of requisition list"
-        id: ID!,
-        "Items to be updated from requisition list"
-        items: [UpdateRequisitionListItemsInput!]!
-    ): UpdateRequisitionListItemsOutput
+        id: ID!, @doc(description: "unique Id of requisition list")
+        items: [UpdateRequisitionListItemsInput!]! @doc(description: "Items to be updated from requisition list")
+    ): UpdateRequisitionListItemsOutput @doc(description: "Update Items in requisition list")
 
-    """
-    Add Requisition List Items To Customer Cart"
-    """
     addRequisitionListItemToCart(
-        "unique Id of requisition list"
-        requisition_list_id: ID!,
-        "selected requisition list items that are to be added"
-        item_ids: [ID!]!
-    ): AddRequisitionListItemToCartOutput
+        requisition_list_id: ID!, @doc(description: "unique Id of requisition list")
+        item_ids: [ID!]! @doc(description: "selected requisition list items that are to be added")
+    ): AddRequisitionListItemToCartOutput @doc(description: "Add Requisition List Items To Customer Cart")
 
-    """
-    Copy Items from Requisition List to another requisition list"
-    """
     copyItemsBetweenRequisitionList(
-        "unique Id of source requisition list"
-        source_id: ID!,
-        "unique Id of destination requisition list"
-        destination_id: ID, # If null new requisition list will be created
-        "selected requisition list items that are to be copied from source"
-        item_ids: [ID!]!
-    ): CopyItemsFromRequisitionListOutput
+        source_id: ID!, @doc(description: "unique Id of source requisition list")
+        destination_id: ID,  @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
+        item_ids: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
+    ): CopyItemsFromRequisitionListOutput @doc(description: "Copy Items from Requisition List to another requisition list")
 
-    """
-    Move Items from Requisition List to another requisition List
-    """
     moveItemsBetweenRequisitionList(
-        "unique Id of source requisition list"
-        source_id: ID!,
-        "unique Id of destination requisition list"
-        destination_id: ID, # If null new requisition list will be created
-        "selected requisition list items that are to be moved from source"
-        item_ids: [ID!]!
-    ): MoveItemsFromRequisitionListOutput
+        source_id: ID!, @doc(description: "unique Id of source requisition list")
+        destination_id: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
+        item_ids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
+    ): MoveItemsFromRequisitionListOutput @doc(description: "Move Items from Requisition List to another requisition List")
 }
 
 type RemoveRequisitionListItemsOutput {
@@ -244,25 +151,20 @@ type AddProductsToRequisitionListOutput {
 }
 
 input RequisitionListFilterInput {
-    "Filter Customer Requisition lists with an requisition list ID or list of requisition list IDs"
-    ids: FilterEqualTypeInput,
-    "Filter by display name of the Requisition list"
-    name: FilterMatchTypeInput
+    ids: FilterEqualTypeInput, @doc(description: "Filter Customer Requisition lists with an requisition list ID or list of requisition list IDs")
+    name: FilterMatchTypeInput @doc(description: "Filter by display name of the Requisition list")
 }
 
 input RequisitionListItemsInput {
     sku: String!
     quantity: Float
     parent_sku: String
-    "selected option ID"
-    selected_options: [String!]
-    "entered Options ID"
-    entered_options: [EnteredOptionInput!]
+    selected_options: [String!] @doc(description: "selected option ID")
+    entered_options: [EnteredOptionInput!] @doc(description: "entered Options ID")
 }
 
 input UpdateRequisitionListItemsInput {
-    "unique ID of Requisition List Item"
-    item_id: ID!
+    item_id: ID! @doc(description: "unique ID of Requisition List Item")
     customizable_options: [CustomizableOptionInput]
     quantity: Float
 }
@@ -284,13 +186,10 @@ type AddRequisitionListItemToCartOutput {
 }
 
 type CopyItemsFromRequisitionListOutput {
-    "Destination Requisition List"
-    list : RequisitionList # since source requisition list is not mutated it is not part of the output
+    list : RequisitionList  @doc(description:  "Destination Requisition List")# since source requisition list is not mutated it is not part of the output
 }
 
 type MoveItemsFromRequisitionListOutput {
-    "Source Requisition List"
-    source : RequisitionList
-    "Destination Requisition List"
-    destination : RequisitionList
+    source : RequisitionList @doc(description:  "Source Requisition List")
+    destination : RequisitionList @doc(description: "Destination Requisition List")
 }

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -214,7 +214,7 @@ type CsvOutput {
     "file name"
     file_name: String
     "data for csv file with headers and records"
-    data: String
+    csv_data: String!
 }
 
 input RequisitionListItemsInput {

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -91,7 +91,6 @@ Requisition List Item Implementation that for Simple and Virtual Products
 type DefaultRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
-    "Product"
     product: ProductInterface!
     "Quantity added"
     qty: Float!
@@ -122,7 +121,6 @@ Requisition List Item Implementation that for Bundle Products
 type BundleRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
-    "Product"
     product: ProductInterface!
     "Quantity added"
     qty: Float!
@@ -138,7 +136,6 @@ Requisition List Item Implementation that for Configurable Products
 type ConfigurableRequisitionListItem implements RequisitionListItemInterface {
     "Unique Identifier of Requisition List Item"
     id: ID!
-    "Product"
     product: ProductInterface!
     "Quantity added"
     qty: Float!

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -175,7 +175,7 @@ type Mutation {
     deleteRequisitionList(
         "unique Id of requisition list"
         id: ID!
-    ): Boolean
+    ): DeleteRequisitionListOutput
 
     """
     Add items to requisition list
@@ -291,6 +291,10 @@ type CreateRequisitionListOutput {
 
 type RenameRequisitionListOutput {
     list: RequisitionList
+}
+
+type DeleteRequisitionListOutput {
+    result: Boolean
 }
 
 type AddRequisitionListItemToCartOutput {

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -220,7 +220,7 @@ type Mutation {
     """
     Copy Items from Requisition List to another requisition list"
     """
-    copyItemsFromRequisitionList(
+    copyItemsBetweenRequisitionList(
         "unique Id of source requisition list"
         source_id: ID!,
         "unique Id of destination requisition list"
@@ -232,7 +232,7 @@ type Mutation {
     """
     Move Items from Requisition List to another requisition List
     """
-    moveItemsFromRequisitionList(
+    moveItemsBetweenRequisitionList(
         "unique Id of source requisition list"
         source_id: ID!,
         "unique Id of destination requisition list"

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -24,17 +24,6 @@
 # `moveItemsFromRequisitionList` and `copyItemsFromRequisitionList` mutations respectively
 #
 
-
-type Query {
-    """
-    Export Requisition list in Csv format
-    """
-    exportRequisitionList(
-        "unqiue Id of Requisition list"
-        id: ID!
-    ): CsvOutput
-}
-
 type Customer {
     "Get Requisition Lists of customer"
     requisitionLists(
@@ -252,13 +241,6 @@ type UpdateRequisitionListItemsOutput {
 
 type AddProductsToRequisitionListOutput {
     requisition_list : RequisitionList
-}
-
-type CsvOutput {
-    "file name"
-    file_name: String
-    "data for csv file with headers and records"
-    csv_data: String!
 }
 
 input RequisitionListFilterInput {


### PR DESCRIPTION
## Problem
Coverage for B2B Requisition List

## Solution
Schema  for B2B Requisition List 

Queries
- All requisition list are available under customer query
- A single requisition list can be queried by Id
- Export Requisition List

Mutations
- Create Requisition List
- Rename Requisition List
- Add Items
- Remove Items
- Update Items
- Copy Items to cart
- Copy Items to another list
- Move Items to another list

## Requested Reviewers
@paliarush 
@lenaorobei 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
