### PR TITLE
Add configured_variant to ConfigurableCartItem

### DIFF
--- a/design-documents/graph-ql/coverage/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/Cart.graphqls
@@ -50,7 +50,7 @@ type VirtualCartItem implements CartItemInterface @doc(description: "Virtual Car
 }
 
 type ConfigurableCartItem implements CartItemInterface {
-    child_sku: String! @doc(description: "SKU of the simple product corresponding to a set of selected configurable options.")
+    configured_variant: SimpleProduct! @doc(description: "Simple product corresponding to configured product.")
     configurable_options: [SelectedConfigurableOption!]
 }
 

--- a/design-documents/graph-ql/coverage/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/Cart.graphqls
@@ -51,7 +51,8 @@ type VirtualCartItem implements CartItemInterface @doc(description: "Virtual Car
 
 type ConfigurableCartItem implements CartItemInterface {
     configured_variant: SimpleProduct! @doc(description: "Simple product corresponding to configured product.")
-    configurable_options: [SelectedConfigurableOption!]
+    configurable_options: [SelectedConfigurableOption!] @deprecated(reason: "use configured_options")
+    configured_options: [SelectedConfigurableOption!] @doc(description: "Configured options for product")
 }
 
 type DownloadableCartItem implements CartItemInterface @doc(description: "Downloadable Cart Item") {


### PR DESCRIPTION
## Problem
When querying cart_items on a cart, the parent product is returned for configurable cart items. This is because ConfigurableCartItem.product corresponds to the parent product. In some cases it is desired to have the configured child product.
One use case is that the product's image is the parent product's image, so it doesn't match the configured selection.

## Solution
The proposed solution is to add an additional field to ConfigurableCartItem, that will contain the simple product that is the configured variant.

## Requested Reviewers
@paliarush 
@akaplya 
