### PR TITLE
Customer order schema updates

### DIFF
--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -153,9 +153,10 @@ type OrderTotal implements SalesTotalAmountInterface {
 @doc("Shipping handling details")
 type ShippingHandling {
     total_amount: Money! @doc("shipping total amount")
-    amount_inc_tax: Money @doc("shipping amount including tax")
-    amount_exc_tax: Money @doc("shipping amount excluding tax")
+    amount_including_tax: Money @doc("shipping amount including tax")
+    amount_excluding_tax: Money @doc("shipping amount excluding tax")
     taxes: [TaxItem] @doc("shipping taxes details")
+    discounts: [Discount] @doc(description: "The applied discounts to the shipping)
 }
 
 @doc("Tax item details")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -268,7 +268,7 @@ type ShipmentTracking {
     number: String @doc("tracking number of the order shipment")
 }
 ```
-### Comments
+## CommentItem type
 ```graphql
 type CommentItem {
     timestamp: String! @doc("The timestamp of the comment")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -176,11 +176,12 @@ type Invoice {
     id: ID! @doc("the ID of the invoice, used for API purposes")
     number: String! @doc("sequential invoice number")
     total: InvoiceTotal! @doc("invoice total amount details")
-    items: [InvoiceItem]! @doc("invoiced product details")
+    items: [InvoiceItemInterface]! @doc("invoiced product details")
+    comments: [InvoiceComment]
 }
 
 @doc("Invoice item details")
-type InvoiceItem {
+type InvoiceItemInterface {
     id: ID! @doc("invoice item unique identifier") #base64encode(invoiceItemId)
     order_item_id: String @doc("link to order item")
     product_name: String @doc("name of the base product")
@@ -189,6 +190,18 @@ type InvoiceItem {
     product_sale_price: Money! @doc("sale price for the base product including selected options")
     discounts: [Discount] @doc("final discount information for the base product including discounts on options")
     quantity_invoiced: Float @doc("number of invoiced items")
+}
+
+type InvoiceItem implements InvoiceItemInterface {
+}
+
+type BundledInvoiceItem implements InvoiceItemInterface {
+    child_items: [InvoiceItemInterface]
+}
+
+type InvoiceComment {
+    timestamp: String!
+    message: String
 }
 
 @doc("Invoice total amount details")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -111,7 +111,7 @@ type OrderItem implements OrderItemInterface {
 }
 
 type BundleOrderItem implements OrderItemInterface {
-    bundle_options: [SelectedBundleOptionItems] @doc("A list of bundle options that are assigned to the bundle product")
+    bundle_options: [ItemSelectedBundleOption] @doc("A list of bundle options that are assigned to the bundle product")
 }
 
 type GiftCardOrderItem implements OrderItemInterface {
@@ -121,10 +121,18 @@ type GiftCardOrderItem implements OrderItemInterface {
     gift_card_message: String @doc("Message accompanying gift card")
 }
 
-type SelectedBundleOptionItems {
-    id: ID! @doc("The unique identifier of the option")
-    label: String! @doc("The label of the option")
-    items: [OrderItemInterface] @doc("A list of products that represent the values of the parent option")
+type ItemSelectedBundleOption {
+    id: ID! @doc(description: "The unique identifier of the option")
+    label: String! @doc(description: "The label of the option")
+    values: [ItemSelectedBundleOptionValue] @doc(description: "A list of products that represent the values of the parent option")
+}
+
+type ItemSelectedBundleOptionValue {
+    id: ID! @doc("unique identifier of option value")
+    product_name: String! @doc("product name for option value")
+    product_sku: String! @doc("product sku for option value")
+    quantity: Float! @doc("quantitity of value selected")
+    price: Money! @doc("Option value price. price for single quantity")
 }
 
 @doc("Represents order item options like selected or entered")
@@ -211,13 +219,7 @@ type InvoiceItem implements InvoiceItemInterface {
 }
 
 type BundleInvoiceItem implements InvoiceItemInterface {
-    bundle_options: [SelectedBundleInvoiceOptionItems] @doc("A list of bundle options that are assigned to the bundle product")
-}
-
-type SelectedBundleInvoiceOptionItems {
-    id: ID! @doc("The unique identifier of the option")
-    label: String! @doc("The label of the option")
-    items: [InvoiceItemInterface] @doc("A list of products that represent the values of the parent option")
+    bundle_options: [ItemSelectedBundleOption] @doc("A list of bundle options that are assigned to the bundle product")
 }
 
 @doc("Invoice total amount details")
@@ -263,13 +265,7 @@ type CreditMemoItem implements CreditMemoItemInterface {
 }
 
 type BundleCreditMemoItem implements CreditMemoIntemInterface {
-    bundle_options: [CreditMemoItemSelectedBundleOptions]
-}
-
-type CreditMemoItemSelectedBundleOptions {
-    id: ID! @doc("The unique identifier of the option")
-    label: String! @doc("The label of the option")
-    items: [CreditMemoItemInterface] @doc("A list of products that represent the values of the parent option")
+    bundle_options: [ItemSelectedBundleOption]
 }
 
 @doc("Credit memo price details")
@@ -309,13 +305,7 @@ type ShipmentItem implements ShipmentItemInterface {
 }
 
 type BundleShipmentItem implements ShipmentItemInterface {
-    bundle_options: [ShipmentItemSelectedBundleOptions]
-}
-
-type ShipmentItemSelectedBundleOptions {
-    id: ID! @doc("The unique identifier of the option")
-    label: String! @doc("The label of the option")
-    items: [ShipmentItemInterface] @doc("A list of products that represent the values of the parent option")
+    bundle_options: [ItemSelectedBundleOption]
 }
 
 @doc("Order shipment tracking details")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -268,6 +268,8 @@ type ShipmentTracking {
     number: String @doc("tracking number of the order shipment")
 }
 ```
+The `id` will be a `base64_encode(increment_id)` which in future can be replaced by UUID.
+
 ## CommentItem type
 ```graphql
 type CommentItem {
@@ -275,7 +277,6 @@ type CommentItem {
     message: String! @doc("the comment message")
 }
 ```
-The `id` will be a `base64_encode(increment_id)` which in future can be replaced by UUID.
 
 ## Additional Types
 

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -183,7 +183,7 @@ type Invoice {
 @doc("Invoice item details")
 type InvoiceItemInterface {
     id: ID! @doc("invoice item unique identifier") #base64encode(invoiceItemId)
-    order_item_id: String @doc("link to order item")
+    order_item: OrderItemInterface @doc("associated order item")
     product_name: String @doc("name of the base product")
     product_sku: String! @doc("SKU of the base product")
     product_type: String @doc("Type of product (e.g. simple, configurable, bundle)")
@@ -225,7 +225,7 @@ type CreditMemo {
 @doc("Credit memo item details")
 type CreditMemoItem {
     id: ID! @doc("Credit memo item unique identifier") #base64encode(creditMemoItemId)
-    order_item_id: String @doc("link to order item")
+    order_item: OrderItemInterface @doc("associated order item")
     product_name: String @doc("name of the base product")
     product_sku: String! @doc("SKU of the base product")
     product_sale_price: Money! @doc("sale price for the base product including selected options")
@@ -234,7 +234,7 @@ type CreditMemoItem {
 }
 
 @doc("Credit memo price details")
-type CredtiMemoTotal implements SalesTotalAmountInterface {
+type CreditMemoTotal implements SalesTotalAmountInterface {
 
 }
 ```
@@ -256,7 +256,7 @@ type OrderShipment {
 @doc("Order shipment item details")
 type ShipmentItem{
     id: ID! @doc("Shipment item unique identifier") #base64encode(shipmentItemId)
-    order_item_id: String @doc("link to order item") 
+    order_item: OrderItemInterface @doc("associated order item")
     product_name: String @doc("name of the base product")
     product_sku: String! @doc("SKU of the base product")
     product_sale_price: Money! @doc("sale price for the base product")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -27,7 +27,7 @@ type CustomerOrders {
 ```graphql
 @doc("Allows to extend the list of search criteria for customer orders")
 input CustomerOrdersFilterInput {
-    number: String @doc("Order number. Allows to filter orders by fully or partial entered number")
+    number: FilterStringTypeInput @doc("Order number. Allows to filter orders by fully or partial entered number")
     status: String @("Order status")
     createdDate: FilterRangeTypeInput
     total: CustomerOrdersAmountFilterInput
@@ -44,6 +44,13 @@ input CustomerOrdersAmountFilterInput {
 input SalesItemFilterInput {
     name: String @doc("Order item name. Allows to filter orders by fully or partial entered order item name")
     sku: String @doc("Order item SKU. Allows to filter orders by fully or partial entered order item SKU")
+}
+
+@doc( "Defines a filter for an input string.")
+input FilterStringTypeInput  {
+    in: [String] @doc("Filters items that are exactly the same as entries specified in an array of strings.")
+    eq: String @doc("Filters items that are exactly the same as the specified string.")
+    match: String @doc("Defines a filter that performs a fuzzy search using the specified string.")
 }
 ```
 
@@ -218,7 +225,7 @@ type CreditMemo {
     id: ID! @doc("the ID of the credit memo, used for API purposes")
     number: String! @doc("sequential credit memo number")
     items: [CreditMemoItem] @doc("items refunded")
-    total: CredtiMemoTotal @doc("refund total amount details")
+    total: CreditMemoTotal @doc("refund total amount details")
     comments: [CommentItem] @doc("comments on the credit memo")
 }
 

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -66,10 +66,10 @@ type CustomerOrder {
     credit_memos: [CreditMemo]! @doc("credit memo list for the order")
     shipments: [OrderShipment]! @doc("shipment list for the order")
     payment_methods: [PaymentMethod]! @doc("payment details for the order")
-    shipping_address: CustomerAddress! @doc("shipping address for the order")
+    shipping_address: CustomerAddress @doc("shipping address for the order")
     billing_address: CustomerAddress! @doc("billing address for the order")
-    carrier: String! @doc("shipping carrier for the order delivery")
-    method: String! @doc("shipping method for the order")
+    carrier: String @doc("shipping carrier for the order delivery")
+    method: String @doc("shipping method for the order")
     comments: [CommentItem]! @doc("comments on the order")
 }
 ```
@@ -219,6 +219,7 @@ type CreditMemo {
     number: String! @doc("sequential credit memo number")
     items: [CreditMemoItem]! @doc("items refunded")
     total: CredtiMemoTotal! @doc("refund total amount details")
+    comments: [CommentItem]! @doc("comments on the credit memo")
 }
 
 @doc("Credit memo item details")
@@ -249,6 +250,7 @@ type OrderShipment {
     number: String! @doc("sequential credit shipment number")
     tracking: [ShipmentTracking] @doc("shipment tracking details")
     items: [ShipmentItem]! @doc("items included in the shipment")
+    comments: [CommentItem]! @doc("comments on the shipment")
 }
 
 @doc("Order shipment item details")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -70,6 +70,7 @@ type CustomerOrder {
     billing_address: CustomerAddress! @doc("billing address for the order")
     carrier: String! @doc("shipping carrier for the order delivery")
     method: String! @doc("shipping method for the order")
+    comments: [CommentItem]! @doc("comments on the order")
 }
 ```
 
@@ -113,7 +114,6 @@ type OrderItemOption {
     value: String! @doc("value of the option")
 }
 ```
-
 ### Payment Method Schema
 
 To provide more customization for different payment solutions, the payment method will be represented by own type instead of simple string:
@@ -177,7 +177,7 @@ type Invoice {
     number: String! @doc("sequential invoice number")
     total: InvoiceTotal! @doc("invoice total amount details")
     items: [InvoiceItemInterface]! @doc("invoiced product details")
-    comments: [InvoiceComment]
+    comments: [CommentItem]! @doc("comments on the invoice")
 }
 
 @doc("Invoice item details")
@@ -197,11 +197,6 @@ type InvoiceItem implements InvoiceItemInterface {
 
 type BundledInvoiceItem implements InvoiceItemInterface {
     child_items: [InvoiceItemInterface]
-}
-
-type InvoiceComment {
-    timestamp: String!
-    message: String
 }
 
 @doc("Invoice total amount details")
@@ -273,7 +268,13 @@ type ShipmentTracking {
     number: String @doc("tracking number of the order shipment")
 }
 ```
-
+### Comments
+```graphql
+type CommentItem {
+    timestamp: String! @doc("The timestamp of the comment")
+    message: String! @doc("the comment message")
+}
+```
 The `id` will be a `base64_encode(increment_id)` which in future can be replaced by UUID.
 
 ## Additional Types

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -82,7 +82,7 @@ The `id` will be a `base64_encode(increment_id)` which in future can be replaced
 
 ```graphql
 @doc("Order item")
-type OrderItemInterface {
+interface OrderItemInterface {
     id: ID! @doc("Order item unique identifier") #base64encode(orderItemId)
     product_name: String @doc("name of the base product")
     product_sku: String! @doc("SKU of the base product")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -60,17 +60,17 @@ type CustomerOrder {
     order_date: String! @doc("date when the order was placed")
     status: String! @doc("current status of the order")
     number: String! @doc("sequential order number")
-    items: [OrderItemInterface]! @doc("collection of all the items purchased")
-    total: OrderTotal! @doc("total amount details for the order")
-    invoices: [Invoice]! @doc("invoice list for the order")
-    credit_memos: [CreditMemo]! @doc("credit memo list for the order")
-    shipments: [OrderShipment]! @doc("shipment list for the order")
-    payment_methods: [PaymentMethod]! @doc("payment details for the order")
+    items: [OrderItemInterface] @doc("collection of all the items purchased")
+    total: OrderTotal @doc("total amount details for the order")
+    invoices: [Invoice] @doc("invoice list for the order")
+    credit_memos: [CreditMemo] @doc("credit memo list for the order")
+    shipments: [OrderShipment] @doc("shipment list for the order")
+    payment_methods: [PaymentMethod] @doc("payment details for the order")
     shipping_address: CustomerAddress @doc("shipping address for the order")
-    billing_address: CustomerAddress! @doc("billing address for the order")
+    billing_address: CustomerAddress @doc("billing address for the order")
     carrier: String @doc("shipping carrier for the order delivery")
     method: String @doc("shipping method for the order")
-    comments: [CommentItem]! @doc("comments on the order")
+    comments: [CommentItem] @doc("comments on the order")
 }
 ```
 
@@ -139,7 +139,7 @@ interface SalesTotalAmountInterface {
     subtotal: Money! @doc("subtotal amount excluding, shipping, discounts and tax")
     discounts: [Discount] @doc("applied discounts")
     total_tax: Money! @doc("total tax amount")
-    taxes: [TaxItem]! @doc("order taxes details")
+    taxes: [TaxItem] @doc("order taxes details")
     grand_total: Money! @doc("final total amount including shipping and taxes")
     base_grand_total: Money! @doc("final total amount in base currency")
 }
@@ -147,7 +147,7 @@ interface SalesTotalAmountInterface {
 @doc("Order total amounts details")
 type OrderTotal implements SalesTotalAmountInterface {
    total_shipping: Money! @doc("order shipping amount")
-   shipping_handling: ShippingHandling! @doc("shipping and handling for the order")
+   shipping_handling: ShippingHandling @doc("shipping and handling for the order")
 }
 
 @doc("Shipping handling details")
@@ -155,7 +155,7 @@ type ShippingHandling {
     total_amount: Money! @doc("shipping total amount")
     amount_inc_tax: Money @doc("shipping amount including tax")
     amount_exc_tax: Money @doc("shipping amount excluding tax")
-    taxes: [TaxItem]! @doc("shipping taxes details")
+    taxes: [TaxItem] @doc("shipping taxes details")
 }
 
 @doc("Tax item details")
@@ -175,9 +175,9 @@ The invoice entity will have the similar to the order schema:
 type Invoice {
     id: ID! @doc("the ID of the invoice, used for API purposes")
     number: String! @doc("sequential invoice number")
-    total: InvoiceTotal! @doc("invoice total amount details")
-    items: [InvoiceItemInterface]! @doc("invoiced product details")
-    comments: [CommentItem]! @doc("comments on the invoice")
+    total: InvoiceTotal @doc("invoice total amount details")
+    items: [InvoiceItemInterface] @doc("invoiced product details")
+    comments: [CommentItem] @doc("comments on the invoice")
 }
 
 @doc("Invoice item details")
@@ -195,14 +195,14 @@ type InvoiceItemInterface {
 type InvoiceItem implements InvoiceItemInterface {
 }
 
-type BundledInvoiceItem implements InvoiceItemInterface {
+type BundleInvoiceItem implements InvoiceItemInterface {
     child_items: [InvoiceItemInterface]
 }
 
 @doc("Invoice total amount details")
 type InvoiceTotal implements SalesTotalAmountInterface {
     total_shipping: Money! @doc("order shipping amount")
-    shipping_handling: ShippingHandling! @doc("shipping and handling for the order")
+    shipping_handling: ShippingHandling @doc("shipping and handling for the order")
 }
 ```
 
@@ -217,9 +217,9 @@ The credit memo entity will have the similar to the order and invoice schema:
 type CreditMemo {
     id: ID! @doc("the ID of the credit memo, used for API purposes")
     number: String! @doc("sequential credit memo number")
-    items: [CreditMemoItem]! @doc("items refunded")
-    total: CredtiMemoTotal! @doc("refund total amount details")
-    comments: [CommentItem]! @doc("comments on the credit memo")
+    items: [CreditMemoItem] @doc("items refunded")
+    total: CredtiMemoTotal @doc("refund total amount details")
+    comments: [CommentItem] @doc("comments on the credit memo")
 }
 
 @doc("Credit memo item details")
@@ -249,8 +249,8 @@ type OrderShipment {
     id: ID! @doc("the ID of the shipment, used for API purposes")
     number: String! @doc("sequential credit shipment number")
     tracking: [ShipmentTracking] @doc("shipment tracking details")
-    items: [ShipmentItem]! @doc("items included in the shipment")
-    comments: [CommentItem]! @doc("comments on the shipment")
+    items: [ShipmentItem] @doc("items included in the shipment")
+    comments: [CommentItem] @doc("comments on the shipment")
 }
 
 @doc("Order shipment item details")

--- a/design-documents/graph-ql/coverage/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer-orders.md
@@ -186,7 +186,6 @@ type InvoiceItemInterface {
     order_item: OrderItemInterface @doc("associated order item")
     product_name: String @doc("name of the base product")
     product_sku: String! @doc("SKU of the base product")
-    product_type: String @doc("Type of product (e.g. simple, configurable, bundle)")
     product_sale_price: Money! @doc("sale price for the base product including selected options")
     discounts: [Discount] @doc("final discount information for the base product including discounts on options")
     quantity_invoiced: Float @doc("number of invoiced items")


### PR DESCRIPTION
## Problem
1. SalesItemInterface is not being used properly as an interface
2. Unclear how to return parent and child items in Orders/Invoices for bundle and configurable products
3. Some shipment fields did not align with available data


## Solution
1. Remove SalesItemInterface and instead use unique types for each item type (OrderItem, InvoiceItem, etc) that have only relevant fields and an ID link to the associated order item
2. For items that distinguish parent and child items (e.g. OrderItem and InvoiceItem) for complex products we introduce an item interface (e.g. OrderItemInterface) so that complex product types can add fields (e.g. BundleOrderItem)
3. Remove ShipmentTracking.link; change ShipmentTracking.method to ShipmentTracking.title because available data does not align with shipping method

Other changes:
Add `comments` field to Order and Invoice

## Requested Reviewers
@joni-jones 
@akaplya 
@paliarush 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
