### PR TITLE
Added replace or merge option for addRequisitionListItemToCart mutation

### DIFF
--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -143,7 +143,7 @@ type Mutation {
 }
 
 type RemoveRequisitionListItemsOutput {
-    requisitionList : RequisitionList
+    requisition_list : RequisitionList
 }
 
 type UpdateRequisitionListItemsOutput {

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -122,7 +122,8 @@ type Mutation {
 
     addRequisitionListItemToCart(
         requisition_list_id: ID!, @doc(description: "unique Id of requisition list")
-        item_ids: [ID!]! @doc(description: "selected requisition list items that are to be added")
+        item_ids: [ID!]!, @doc(description: "selected requisition list items that are to be added")
+	is_replace: Boolean @doc(description: "replaces or merges the existing cart items with requisition list items")
     ): AddRequisitionListItemToCartOutput @doc(description: "Add Requisition List Items To Customer Cart")
 
     copyItemsBetweenRequisitionList(

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -121,29 +121,29 @@ type Mutation {
     ): UpdateRequisitionListItemsOutput @doc(description: "Update Items in requisition list")
 
     addRequisitionListItemToCart(
-        requisition_list_id: ID!, @doc(description: "unique Id of requisition list")
-        item_ids: [ID!]! @doc(description: "selected requisition list items that are to be added")
+        requisitionListId: ID!, @doc(description: "unique Id of requisition list")
+        itemIds: [ID!]! @doc(description: "selected requisition list items that are to be added")
     ): AddRequisitionListItemToCartOutput @doc(description: "Add Requisition List Items To Customer Cart")
 
     copyItemsBetweenRequisitionList(
-        source_id: ID!, @doc(description: "unique Id of source requisition list")
-        destination_id: ID,  @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
-        item_ids: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
+        sourceId: ID!, @doc(description: "unique Id of source requisition list")
+        destinationId: ID,  @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
+        itemIds: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
     ): CopyItemsFromRequisitionListOutput @doc(description: "Copy Items from Requisition List to another requisition list")
 
     moveItemsBetweenRequisitionList(
-        source_id: ID!, @doc(description: "unique Id of source requisition list")
-        destination_id: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
-        item_ids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
+        sourceId: ID!, @doc(description: "unique Id of source requisition list")
+        destinationId: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
+        itemIds: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
     ): MoveItemsFromRequisitionListOutput @doc(description: "Move Items from Requisition List to another requisition List")
 
     clearCustomerCart(
-	cart_id: String! @doc(description: "masked Cart Id")
+	cartId: String! @doc(description: "masked Cart Id")
     ): ClearCustomerCartOutput @doc(description: "Clears the cart items")
 }
 
 type RemoveRequisitionListItemsOutput {
-    requisition_list : RequisitionList
+    requisitionList : RequisitionList
 }
 
 type UpdateRequisitionListItemsOutput {

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -122,8 +122,7 @@ type Mutation {
 
     addRequisitionListItemToCart(
         requisition_list_id: ID!, @doc(description: "unique Id of requisition list")
-        item_ids: [ID!]!, @doc(description: "selected requisition list items that are to be added")
-	is_replace: Boolean @doc(description: "replaces or merges the existing cart items with requisition list items")
+        item_ids: [ID!]! @doc(description: "selected requisition list items that are to be added")
     ): AddRequisitionListItemToCartOutput @doc(description: "Add Requisition List Items To Customer Cart")
 
     copyItemsBetweenRequisitionList(
@@ -137,6 +136,10 @@ type Mutation {
         destination_id: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
         item_ids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
     ): MoveItemsFromRequisitionListOutput @doc(description: "Move Items from Requisition List to another requisition List")
+
+    clearCustomerCart(
+	cart_id: String! @doc(description: "masked Cart Id")
+    ): ClearCustomerCartOutput @doc(description: "Clears the cart items")
 }
 
 type RemoveRequisitionListItemsOutput {
@@ -193,4 +196,8 @@ type CopyItemsFromRequisitionListOutput {
 type MoveItemsFromRequisitionListOutput {
     source : RequisitionList @doc(description:  "Source Requisition List")
     destination : RequisitionList @doc(description: "Destination Requisition List")
+}
+
+type ClearCustomerCartOutput {
+    cart: Cart
 }


### PR DESCRIPTION
## Problem

Whenever we add requisition list items to cart if the cart has items we have an option to replace or merge the requisition list items with the existing cart items. We don't have the option in the addRequisitionListItemToCart mutation.

## Solution

Added a seperate parameter ( is_replace ) to the addRequisitionListItemToCart mutation.

## Requested Reviewers
@nrkapoor @paliarush 
