### PR TITLE
pagination to support entities in b2b

### DIFF
--- a/design-documents/graph-ql/coverage/cart/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/cart/Cart.graphqls
@@ -17,7 +17,7 @@ type Cart {
     items_v2(
         currentPage: Int = 1 @doc(description: "current page of the customer cart items. default is 1")
         pageSize: Int = 20 @doc(description: "page size for the customer cart items. default is 20")
-    ): CartItems! @doc(description: "collection of all the items purchased")
+    ): CartItems! @doc(description: "Cart items")
     applied_coupons: [AppliedCoupon] @doc(description:"An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code. By default Magento supports only one coupon.")
     email: String
     shipping_addresses: [ShippingCartAddress]!
@@ -30,9 +30,9 @@ type Cart {
 }
 
 type CartItems {
-    items: [CartItemInterface] @doc(description: "Cart items list")
+    items: [CartItemInterface]! @doc(description: "Cart items list")
     page_info: SearchResultPageInfo
-    total_count: Int
+    total_count: Int!
 }
 
 type AvailablePaymentMethod {

--- a/design-documents/graph-ql/coverage/cart/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/cart/Cart.graphqls
@@ -13,7 +13,7 @@ type CartQueryOutput {
 type Cart {
     id: ID! @doc(description: "The ID of the cart.") @deprecated(reason: "use uid")
     uid: ID! @doc(description: "The unique ID of the cart.")
-    items: [CartItemInterface]
+    items: [CartItemInterface] @deprecated(reason: "The `items` field is deprecated. Use `items_v2` instead.")
     items_v2(
         currentPage: Int = 1 @doc(description: "current page of the customer cart items. default is 1")
         pageSize: Int = 20 @doc(description: "page size for the customer cart items. default is 20")

--- a/design-documents/graph-ql/coverage/cart/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/cart/Cart.graphqls
@@ -14,6 +14,10 @@ type Cart {
     id: ID! @doc(description: "The ID of the cart.") @deprecated(reason: "use uid")
     uid: ID! @doc(description: "The unique ID of the cart.")
     items: [CartItemInterface]
+    items_v2(
+        currentPage: Int = 1 @doc(description: "current page of the customer cart items. default is 1")
+        pageSize: Int = 20 @doc(description: "page size for the customer cart items. default is 20")
+    ): CartItems! @doc(description: "collection of all the items purchased")
     applied_coupons: [AppliedCoupon] @doc(description:"An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code. By default Magento supports only one coupon.")
     email: String
     shipping_addresses: [ShippingCartAddress]!
@@ -23,6 +27,12 @@ type Cart {
     prices: CartPrices
     total_quantity: Float!
     is_virtual: Boolean!
+}
+
+type CartItems {
+    items: [CartItemInterface] @doc(description: "Cart items list")
+    page_info: SearchResultPageInfo
+    total_count: Int
 }
 
 type AvailablePaymentMethod {

--- a/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
+++ b/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
@@ -8,7 +8,7 @@ type Customer {
 }
 
 type CustomerAddresses {
-    items: [CustomerAddress] @doc(description: "Customer Address List")
+    items: [CustomerAddress]! @doc(description: "List of customer address")
     page_info: SearchResultPageInfo
-    total_count: Int
+    total_count: Int!
 }

--- a/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
+++ b/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
@@ -4,7 +4,7 @@ type Customer {
     addresses_v2(
         currentPage: Int = 1 @doc(description: "current page of the customer address list. default is 1")
         pageSize: Int = 10 @doc(description: "page size for the customer address list. default is 10")
-    ): CustomerAddresses
+    ): CustomerAddresses!
 }
 
 type CustomerAddresses {

--- a/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
+++ b/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
@@ -1,4 +1,6 @@
+#
 type Customer {
+    addresses: CustomerAddresses @deprecated(reason: "The `address` field is deprecated. Use `addresses_v2` instead.")
     addresses_v2(
         currentPage: Int = 1 @doc(description: "current page of the customer address list. default is 1")
         pageSize: Int = 10 @doc(description: "page size for the customer address list. default is 10")

--- a/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
+++ b/design-documents/graph-ql/coverage/customer-address-pagination-change.graphqls
@@ -1,0 +1,12 @@
+type Customer {
+    addresses_v2(
+        currentPage: Int = 1 @doc(description: "current page of the customer address list. default is 1")
+        pageSize: Int = 10 @doc(description: "page size for the customer address list. default is 10")
+    ): CustomerAddresses
+}
+
+type CustomerAddresses {
+    items: [CustomerAddress] @doc(description: "Customer Address List")
+    page_info: SearchResultPageInfo
+    total_count: Int
+}

--- a/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
+++ b/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
@@ -14,12 +14,22 @@ type Customer {
 
 type Wishlist {
     id: ID
-    items: [WishlistItem] @deprecated(reason: "Use field `items_v2` from type `Wishlist` instead")
-    items_v2: [WishlistItemInterface] @doc(description: "An array of items in the customer's wishlist")
+    items: [WishlistItem] @deprecated(reason: "Use field `items_v3` from type `Wishlist` instead")
+    items_v2: [WishlistItemInterface] @doc(description: "An array of items in the customer's wishlist") @deprecated(reason: "Use field `items_v3` from type `Wishlist` instead")
+    items_v3(
+        currentPage: Int = 1 @doc(description: "current page of the customer wishlist items. default is 1")
+        pageSize: Int = 20 @doc(description: "page size for the customer wishlist items. default is 20")
+    ): WishlistItems @doc(description: "An array of items in the customer's wishlist")
     items_count: Int
     sharing_code: String
     updated_at: String
     name: String @doc(description: "Avaialble in Commerce edition only")
+}
+
+type WishlistItems {
+    items: [WishlistItemInterface]
+    page_info: SearchResultPageInfo
+    total_count: Int
 }
 
 input WishlistItemUpdateInput {

--- a/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
+++ b/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
@@ -19,7 +19,7 @@ type Wishlist {
     items_v3(
         currentPage: Int = 1 @doc(description: "current page of the customer wishlist items. default is 1")
         pageSize: Int = 20 @doc(description: "page size for the customer wishlist items. default is 20")
-    ): WishlistItems @doc(description: "An array of items in the customer's wishlist")
+    ): WishlistItems! @doc(description: "An array of items in the customer's wishlist")
     items_count: Int
     sharing_code: String
     updated_at: String

--- a/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
+++ b/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
@@ -27,9 +27,9 @@ type Wishlist {
 }
 
 type WishlistItems {
-    items: [WishlistItemInterface]
+    items: [WishlistItemInterface]!
     page_info: SearchResultPageInfo
-    total_count: Int
+    total_count: Int!
 }
 
 input WishlistItemUpdateInput {
@@ -97,4 +97,3 @@ type GiftCardWishlistItem implements WishlistItemInterface {
     amount: SelectedGiftCardAmount
     message: String
 }
-

--- a/design-documents/graph-ql/coverage/customer/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer/customer-orders.md
@@ -67,7 +67,7 @@ type CustomerOrder {
     order_date: String! @doc("date when the order was placed")
     status: String! @doc("current status of the order")
     number: String! @doc("sequential order number")
-    items: [OrderItemInterface] @doc("collection of all the items purchased")
+    items: [OrderItemInterface] @doc("collection of all the items purchased") @deprecated("The `items` field is derecated. Use `items_v2` instead.")
     items_v2(
              currentPage: Int = 1 @doc("current page of the customer order item list. default is 1")
              pageSize: Int = 20 @doc("page size for the customer orders item list. default is 20")

--- a/design-documents/graph-ql/coverage/customer/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer/customer-orders.md
@@ -68,6 +68,10 @@ type CustomerOrder {
     status: String! @doc("current status of the order")
     number: String! @doc("sequential order number")
     items: [OrderItemInterface] @doc("collection of all the items purchased")
+    items_v2(
+             currentPage: Int = 1 @doc("current page of the customer order item list. default is 1")
+             pageSize: Int = 20 @doc("page size for the customer orders item list. default is 20")
+             ): OrderItems! @doc("collection of all the items purchased with pagination")
     total: OrderTotal @doc("total amount details for the order")
     invoices: [Invoice] @doc("invoice list for the order")
     credit_memos: [CreditMemo] @doc("credit memo list for the order")
@@ -86,6 +90,17 @@ The `id` will be a `base64_encode(increment_id)` which in future can be replaced
 > The order `status` should be filtered in the same way as for Luma via `Order Status` and `Visible On Storefront` configuration 
 
 ### Order Item
+The order items will be presented as separate interface which will have multiple implementations for invoice, shipment and credit memo types.
+The order items will be paginated.
+
+```graphql
+@doc("Grpahql Order Item Output Wrapper")
+type OrderItems {
+    items: [OrderItem]  @doc("collection of customer orders items that contains individual order item details.")
+    page_info: SearchResultPageInfo
+    total_count: Int
+}
+```
 
 ```graphql
 interface OrderItemInterface @doc("Order item details") {

--- a/design-documents/graph-ql/coverage/customer/customer-orders.md
+++ b/design-documents/graph-ql/coverage/customer/customer-orders.md
@@ -71,7 +71,7 @@ type CustomerOrder {
     items_v2(
              currentPage: Int = 1 @doc("current page of the customer order item list. default is 1")
              pageSize: Int = 20 @doc("page size for the customer orders item list. default is 20")
-             ): OrderItems! @doc("collection of all the items purchased with pagination")
+    ): OrderItems! @doc("Collection of all of the purchased items")
     total: OrderTotal @doc("total amount details for the order")
     invoices: [Invoice] @doc("invoice list for the order")
     credit_memos: [CreditMemo] @doc("credit memo list for the order")
@@ -96,9 +96,9 @@ The order items will be paginated.
 ```graphql
 @doc("Grpahql Order Item Output Wrapper")
 type OrderItems {
-    items: [OrderItem]  @doc("collection of customer orders items that contains individual order item details.")
+    items: [OrderItem]!  @doc("List of orders items")
     page_info: SearchResultPageInfo
-    total_count: Int
+    total_count: Int!
 }
 ```
 


### PR DESCRIPTION
## Problem

Current Graphql endpoints like cartItems, address, order  items etc are not paginated. In B2B scenarios, these could impact performance because of large number of items will be returned in collection.

## Solution

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->
Adding pagination for  entities.
Cart Items,
Order Items,
Customer Addresses 

## Requested Reviewers
@nrkapoor 
@paliarush 
@DrewML 

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
