### PR TITLE
req list items pagiantion

### DIFF
--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -174,7 +174,8 @@ input RequisitionListItemsInput {
 
 input UpdateRequisitionListItemsInput {
     item_id: ID! @doc(description: "unique ID of Requisition List Item")
-    customizable_options: [CustomizableOptionInput]
+    selected_options: [String!] @doc(description: "selected option ID")
+    entered_options: [EnteredOptionInput!] @doc(description: "entered Options ID")
     quantity: Float
 }
 

--- a/design-documents/graph-ql/coverage/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/requisitionList.graphqls
@@ -42,9 +42,18 @@ type RequisitionList @doc(description: "Requisition List Type") {
     id: ID! @doc(description: "Unique Identifier of Requisition List")
     name: String! @doc(description: "Name of the list")
     description: String @doc(description: "Description of the list")
-    items: [RequisitionListItemInterface] @doc(description: "Items in the list")
+    items(
+        currentPage: Int = 1,
+        pageSize: Int = 20
+    ): RequistionListItems
     items_count: Int! @doc(description: "Number of items in list")
     updated_at: String @doc(description: "Latest Activity")
+}
+
+type RequistionListItems {
+    items: [RequisitionListItemInterface] @doc(description: "Requisition List items list")
+    page_info: SearchResultPageInfo
+    total_pages: Int @doc(description: "total count of req list items")
 }
 
 interface RequisitionListItemInterface @doc(description: "Interface type for Requisition List Item") {


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
Requisition List Items size can be huge and can be a performance issue. Current schema doesn't  handle it.
Update Requisition List items cannot handle edit config variation, adding the support from Alex request
## Solution
Adding pagination to Requisition List Items
Update to Req list items Input for supporting custom options, configurable options.
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers
@nrkapoor 
@DrewML 
@paliarush 
@cpartica 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
