### PR TITLE
[Reward Points] Add RewardPointsRate type for RewardPointsExchangeRates

### DIFF
--- a/design-documents/graph-ql/coverage/reward-points.graphqls
+++ b/design-documents/graph-ql/coverage/reward-points.graphqls
@@ -32,8 +32,13 @@ type RewardPointsAmount {
 }
 
 type RewardPointsExchangeRates @doc (description: "Exchange rates depend on the customer group"){
-    earning: Float! @doc(description: "How many points are earned per 1 currency spent")
-    redemption: Float! @doc(description: "How many points need to be redeemed to get 1 currency discount at the checkout")
+    earning: RewardPointsRate @doc(description: "How many points are earned for a given amount spent")
+    redemption: RewardPointsRate @doc(description: "How many points must be redeemed to get a given amount of currency discount at the checkout")
+}
+
+type RewardPointsRate {
+    points: Float! @doc(description: "The number of points for exchange rate. For earnings this this the number of points earned. For redemption this is the number of points needed for redemption.")
+    currency_amount: Float! @doc(description: "The money value for exchange rate. For earnings this is amount spent to earn the specified points. For redemption this is the amount of money the number of points represents.")
 }
 
 type RewardPointsSubscriptionStatus {


### PR DESCRIPTION
## Problem
Reward point exchange rates are discrete (not continuous) so a float value representing the exchange rate it not sufficient.
i.e.
An earning rate of $10:100points does not mean that $1 will earn 10points, so an exchange rate of 10% is misleading.
The customer gets 100points for every $10 spent, not 10 points for every $1 spent.
Redemption follows the same principle.

## Solution
Create a type for exchange rates that explicitly states the point:money conversion.

## Requested Reviewers
@paliarush 
@DrewML 

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
