### PR TITLE
Proposal to solve dependency in GQL schema between QuoteGQL and WishlistGQL

### DIFF
--- a/design-documents/graph-ql/coverage/AddProductsToCart.graphqls
+++ b/design-documents/graph-ql/coverage/AddProductsToCart.graphqls
@@ -10,6 +10,7 @@ input CartItemInput {
     entered_options: [EnteredOptionInput!] # will not be used in deprecated methods
 }
 
+# Place this input type in GraphQl Module to avoid dependency between WishlistGraphQl and QuoteGraphQl (And possible cross dependencies in the future).
 input EnteredOptionInput {
     uid: ID!
     value: String!


### PR DESCRIPTION

## Problem

Based on the uid changes, new/existing mutations in the future will be leveraging the EnteredOptionInput type. 
```
input EnteredOptionInput {
    uid: ID!
    value: String!
}
```
Based on this architecture [AddProductsToCart](https://github.com/magento/architecture/blob/master/design-documents/graph-ql/coverage/AddProductsToCart.graphqls) the type EnteredOptionInput is inferred to be in QuoteGQL module. 

The same type is being used in WishlistGQL [Wishlist](https://github.com/magento/architecture/blob/0cc6ac2eba3177b23409cb230e45ba394c949914/design-documents/graph-ql/coverage/Wishlist.graphqls#L29) for its mutations. This creates a dependency between WishlistGQL and QuoteGQL.

 
## Solution

There a couple of ways to fix this.

Solution 1. Move the ```EnteredOptionInput``` to the GraphQL framework module, which will avoid cross dependencies across modules except for the framework module. (Added in the document)

Solution 2. Rename field names specific to the modules, possibly ```WishlistEnteredOptionInput``` and ```CartItemEnteredOptionInput``` and have the type on respective modules. This introduces a very minimum level of duplication but the provides the flexibility to update input types in the future. Flexibility plays a key role here, since modifying input types impacts the mutations in which the those types are being used in. 

Solution 3. Create a new module to move this type to. This might be an overkill for just a type.

## Requested Reviewers

@paliarush @akaplya @DrewML 

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
