### PR TITLE
negotiable-quote-graphql-schema-improvement

### DIFF
--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -172,7 +172,7 @@ enum NegotiableQuoteCommentCreatorType {
 type NegotiableQuote {
     id: ID!
     name: String!
-    items: [NegotiableQuoteItem!]
+    items: [CartItemInterface!]
     # Attachment Support is dependent on headless File Upload design
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
@@ -196,11 +196,6 @@ enum NegotiableQuoteStatus {
     CLOSED
     DECLINED
     EXPIRED
-}
-
-type NegotiableQuoteItem @doc(description: "A line item on a Negotiable Quote") {
-    id: ID! @doc(description: "ID of the line item (not product) in a Negotiable Quote")
-    item: CartItemInterface @doc(description: "Product assigned to line item, with selected configurations")
 }
 
 input NegotiableQuoteFilterInput {
@@ -247,8 +242,8 @@ type NegotiableQuoteHistoryChanges {
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L40-L73
 type NegotiableQuoteHistoryStatusChange {
-    old_status: NegotiableQuoteStatus @doc(description: "Will be null for the first history entry on a Negotiable Quote")
-    new_status: NegotiableQuoteStatus!
+    old_status: String @doc(description: "Will be null for the first history entry on a Negotiable Quote")
+    new_status: String! @doc(description: "Negotiable Quote History New Status.")
 }
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L48

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -99,11 +99,7 @@ type DeleteNegotiableQuotesOutput {
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
-    negotiable_quotes(
-        filter: NegotiableQuoteFilterInput,
-        pageSize: Int = 20,
-        currentPage: Int = 1
-    ): NegotiableQuotesOutput @doc(description: "List of negotiable quotes available to customer")
+    quote: Boolean
 }
 
 input CloseNegotiableQuotesInput {
@@ -112,11 +108,6 @@ input CloseNegotiableQuotesInput {
 
 type CloseNegotiableQuotesOutput {
     closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed")
-    negotiable_quotes(
-        filter: NegotiableQuoteFilterInput,
-        pageSize: Int = 20,
-        currentPage: Int = 1
-    ): NegotiableQuotesOutput @doc(description: A (optionally filtered) list of Negotiable Quotes viewable by the logged-in customer")
 }
 
 input RemoveNegotiableQuoteItemsInput {

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -111,7 +111,7 @@ input CloseNegotiableQuotesInput {
 }
 
 type CloseNegotiableQuotesOutput {
-    closed_quotes: [NegotiableQuote]! @doc(description: "Quotes that were just closed")
+    closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed")
     negotiable_quotes(
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -242,8 +242,8 @@ type NegotiableQuoteHistoryChanges {
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L40-L73
 type NegotiableQuoteHistoryStatusChange {
-    old_status: String @doc(description: "Will be null for the first history entry on a Negotiable Quote")
-    new_status: String! @doc(description: "Negotiable Quote History New Status.")
+    old_status: NegotiableQuoteStatus @doc(description: "Will be null for the first history entry on a Negotiable Quote")
+    new_status: NegotiableQuoteStatus! @doc(description: "Negotiable Quote History New Status.")
 }
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L48
@@ -261,8 +261,8 @@ type NegotiableQuoteHistoryCommentChange {
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L259-L294
 type NegotiableQuoteHistoryTotalChange {
-    old_price: Money!
-    new_price: Money!
+    old_price: Money
+    new_price: Money
 }
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L74-L103

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -103,7 +103,7 @@ type DeleteNegotiableQuotesOutput {
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,
         currentPage: Int = 1
-    ): NegotiableQuotesOutput @resolver(class: "\\Magento\\NegotiableQuoteGraphQl\\Model\\Resolver\\GetNegotiableQuotes") @doc(description: "List of negotiable quotes available to customer")
+    ): NegotiableQuotesOutput @doc(description: "List of negotiable quotes available to customer")
 }
 
 input CloseNegotiableQuotesInput {

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -99,7 +99,7 @@ type DeleteNegotiableQuotesOutput {
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
-    negotiableQuotes(
+    negotiable_quotes(
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,
         currentPage: Int = 1
@@ -113,7 +113,7 @@ input CloseNegotiableQuotesInput {
 type CloseNegotiableQuotesOutput {
     closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed")
     #optionally display all negotiable quotes
-    negotiableQuotes(
+    negotiable_quotes(
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,
         currentPage: Int = 1

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -42,11 +42,6 @@ type Mutation {
         input: RemoveNegotiableQuoteItemsInput!
     ): RemoveNegotiableQuoteItemsOutput @doc(description: "Remove 1 or more products from a Negotiable Quote")
 
-    # Covers "buyer can add items" of https://devdocs.magento.com/guides/v2.4/b2b/negotiable-update.html#add-a-new-quote-item-to-the-negotiable-quote
-    addNegotiableQuoteItems(
-        input: AddNegotiableQuoteItemsInput!
-    ): AddNegotiableQuoteItemsOutput @doc(description: "Add 1 or more products to a Negotiable Quote")
-
     # Covers first half of https://docs.magento.com/user-guide/customers/account-dashboard-quotes.html#cancel-a-quote-request
     closeNegotiableQuotes(
         input: CloseNegotiableQuotesInput!

--- a/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/negotiableQuotes.graphqls
@@ -99,7 +99,11 @@ type DeleteNegotiableQuotesOutput {
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
-    quote: Boolean
+    negotiableQuotes(
+        filter: NegotiableQuoteFilterInput,
+        pageSize: Int = 20,
+        currentPage: Int = 1
+    ): NegotiableQuotesOutput @resolver(class: "\\Magento\\NegotiableQuoteGraphQl\\Model\\Resolver\\GetNegotiableQuotes") @doc(description: "List of negotiable quotes available to customer")
 }
 
 input CloseNegotiableQuotesInput {
@@ -108,6 +112,12 @@ input CloseNegotiableQuotesInput {
 
 type CloseNegotiableQuotesOutput {
     closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed")
+    #optionally display all negotiable quotes
+    negotiableQuotes(
+        filter: NegotiableQuoteFilterInput,
+        pageSize: Int = 20,
+        currentPage: Int = 1
+    ): NegotiableQuotesOutput @doc(description: "A (optionally filtered) list of Negotiable Quotes viewable by the logged-in customer")
 }
 
 input RemoveNegotiableQuoteItemsInput {


### PR DESCRIPTION
## Problem

The NegotiableQuote Graphql architectural schema was not aligned with the implementation. Need to change the type to implementation fit.

## Solution

During the Development time of the Negotiable Quote GraphQl, We have faced ENUMERATION TYPE Null Issue for the NegotiableQuoteHistoryStatusChange with old_status because old_status will be return null for the first iteration of history log of the current Quote and this will throw the error. We have added String type instead of ENUM.

Update schema to reflect the implementation of items object and NegotiableQuoteHistoryStatusChange.

## Requested Reviewers
@paliarush 
@DrewML 

