### PR TITLE
Update GraphQl company create mutation output

### DIFF
--- a/design-documents/graph-ql/coverage/company.md
+++ b/design-documents/graph-ql/coverage/company.md
@@ -174,7 +174,18 @@ type DeleteCompanyTeamOutput @doc(description: "Delete company team output data 
 }
 
 type CreateCompanyOutput @doc(description: "Create company output data schema.") {
-    company: Company! @doc(description: "New company instance.")
+    company: CompanyOutput! @doc(description: "Create company output instance.")
+}
+
+type CompanyOutput {
+    id: ID! @doc(description: "Company id.")
+    name: String @doc(description: "Company name.")
+    email: String @doc(description: "Company email address.")
+    legal_name: String @doc(description: "Company legal name.")
+    vat_id: String @doc(description: "Company VAT/TAX id.")
+    reseller_id: String @doc(description: "Company re-seller id.")
+    legal_address: CompanyLegalAddress! @doc(description: "An object containing Company legal address data.")
+    company_admin: Customer! @doc(description: "An object containing Company Administrator information.")
 }
 
 type UpdateCompanyOutput @doc(description: "Update company output data schema.")  {
@@ -208,7 +219,6 @@ type DeleteCompanyRoleOutput @doc(description: "Delete company role output data 
 type UpdateCompanyStructureOutput @doc(description: "Update company structure output data schema.") {
     company: Company! @doc(description: "Updated company instance.")
 }
-
 
 input CompanyCreateInput @doc(description: "Defines the Company input data schema for creating a new entity."){
     company_name: String! @doc(description: "Company name. Required.")


### PR DESCRIPTION
## Problem

The type of CreateCompanyOutput for company create mutation is defined as type "Company". The fields of Company in current implementation have their own resolver in which the authorization will be checked. It would fail for creating company because in this case we do not have a logged in user. 

## Solution

Update schema with base fields like the response for company registration in frontend. No additional fields like "role", "users", "structure" etc.

## Requested Reviewers

@paliarush
@cpartica 
@danielrenaud 
