### PR TITLE
Rename id fields to uid in returns.graphqls

### DIFF
--- a/design-documents/graph-ql/coverage/returns.graphqls
+++ b/design-documents/graph-ql/coverage/returns.graphqls
@@ -27,7 +27,7 @@ input RequestReturnItemInput {
 }
 
 input EnteredCustomAttributeInput {
-    id: ID!
+    uid: ID!
     value: String!
 }
 
@@ -81,7 +81,7 @@ type Customer {
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. Defaults to 20."),
         currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1."),
     ): Returns @doc(description: "Information about the customer returns.")
-    return(id: ID!): Return @doc(description: "Get customer return details by its ID.")
+    return(uid: ID!): Return @doc(description: "Get customer return details by its ID.")
 }
 
 type CustomerOrder {
@@ -103,7 +103,7 @@ type Returns {
 }
 
 type Return @doc(description: "Customer return") {
-    id: ID!
+    uid: ID!
     number: String! @doc(description: "Human-readable return number")
     order: CustomerOrder @doc(description: "The order associated with the return.")
     creation_date: String! @doc(description: "The date when the return was requested.")
@@ -117,7 +117,7 @@ type Return @doc(description: "Customer return") {
 }
 
 type ReturnItem {
-    id: ID!
+    uid: ID!
     order_item: OrderItemInterface! @doc(description: "Order item provides access to the product being returned, including selected/entered options information.")
     custom_attributes: [CustomAttribute] @doc(description: "Return item custom attributes, which are marked by the admin to be visible on the storefront.")
     request_quantity: Float! @doc(description: "The quantity of the item requested to be returned.")
@@ -127,13 +127,13 @@ type ReturnItem {
 
 # See https://github.com/magento/architecture/blob/master/design-documents/graph-ql/custom-attributes-container.md
 type CustomAttribute {
-    id: ID!
+    uid: ID!
     label: String!
     value: String! @doc(description: "JSON encoded value of the attribute.")
 }
 
 type ReturnComment {
-    id: ID! @doc(description: "Comment ID.")
+    uid: ID! @doc(description: "Comment ID.")
     author_firstname: String! @doc(description: "First name of the user who posted the comment.")
     author_lastname: String! @doc(description: "Last name of the user who posted the comment.")
     created_at: String! @doc(description: "The date and time when the comment was posted.")
@@ -142,16 +142,16 @@ type ReturnComment {
 
 type ReturnShipping {
     address: ReturnShippingAddress @doc(description: "Return shipping address, which is specified by the admin.")
-    tracking(id: ID): [ReturnShippingTracking] @doc(description: "Tracking information for all or a single tracking record when ID is provided.")
+    tracking(uid: ID): [ReturnShippingTracking] @doc(description: "Tracking information for all or a single tracking record when ID is provided.")
 }
 
 type ReturnShippingCarrier {
-    id: ID!
+    uid: ID!
     label: String!
 }
 
 type ReturnShippingTracking {
-    id: ID!
+    uid: ID!
     carrier: ReturnShippingCarrier!
     tracking_number: String!
     status: ReturnShippingTrackingStatus
@@ -207,9 +207,9 @@ type StoreConfig {
 }
 
 type Attribute {
-    id: ID!
+    uid: ID!
 }
 
 type AttributeOption {
-    id: ID!
+    uid: ID!
 }


### PR DESCRIPTION
## Problem

Schema has a lot of fields named id which doesn't align with the new naming convention.


## Solution

Updating all id fields to uid to be consistent with the new naming convention.


## Requested Reviewers

@melnikovi @prabhuram93