### PR TITLE
Rename all id fields to uid in cart.graphqls

### DIFF
--- a/design-documents/graph-ql/coverage/cart/Cart.graphqls
+++ b/design-documents/graph-ql/coverage/cart/Cart.graphqls
@@ -3,7 +3,7 @@ type Query {
 }
 
 input CartQueryInput {
-    cart_id: String!
+    cart_id: ID!
 }
 
 type CartQueryOutput {
@@ -11,7 +11,8 @@ type CartQueryOutput {
 }
 
 type Cart {
-    id: ID! @doc(description: "The ID of the cart.")
+    id: ID! @doc(description: "The ID of the cart.") @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the cart.")
     items: [CartItemInterface]
     applied_coupons: [AppliedCoupon] @doc(description:"An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code. By default Magento supports only one coupon.")
     email: String
@@ -36,7 +37,8 @@ type SelectedPaymentMethod {
 }
 
 interface CartItemInterface @typeResolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CartItemTypeResolver") {
-    id: String!
+    id: String! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the cart item.")
     quantity: Float!
     prices: CartItemPrices
     product: ProductInterface!
@@ -74,8 +76,9 @@ type GiftCardCartItem implements CartItemInterface {
 
 type SelectedConfigurableOption {
     # Hash which includes option ID, option type and slected values. Can be used to move configurable product to wishlist or gift registry
-    id_v2: ID!
-    id: Int!
+    id_v2: ID! @deprecated(reason: "use uid")
+    id: Int! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the cart.")
     option_label: String!
     value_id: Int!
     value_label: String!
@@ -83,7 +86,8 @@ type SelectedConfigurableOption {
 
 type DownloadableProductLink @doc(description: "Defines characteristics of a downloadable product") {
     # Hash based on option type and slected link. Can be used to move downloadable product to wishlist or gift registry
-    id: ID!
+    id: ID! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the cart.")
     title: String @doc(description: "The display name of the link")
     sort_order: Int @doc(description: "A number indicating the sort order")
     price: Float @doc(description: "The price of the downloadable product")
@@ -97,14 +101,16 @@ type DownloadableProductSamples @doc(description: "DownloadableProductSamples de
 }
 
 type SelectedBundleOption {
-    id: Int!
+    id: Int! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the cart.")
     label: String!
     type: String!
     values: [SelectedBundleOptionValue!]!
 }
 
 type SelectedBundleOptionValue {
-    id: Int!
+    id: Int! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the cart.")
     label: String!
     price: Float!
     quantity: Float!
@@ -113,8 +119,9 @@ type SelectedBundleOptionValue {
 
 type SelectedCustomizableOption {
     # Hash which includes option ID, option type and slected values. Can be used to move a product to wishlist or gift registry
-    id_v2: ID!
-    id: Int!
+    id_v2: ID! @deprecated(reason: "use uid")
+    id: Int!  @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the selected option.")
     label: String!
     is_required: Boolean!
     values: [SelectedCustomizableOptionValue!]!
@@ -122,7 +129,8 @@ type SelectedCustomizableOption {
 }
 
 type SelectedCustomizableOptionValue {
-    id: Int!
+    id: Int! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the selected option.")
     label: String!
     value: String!
     price: CartItemSelectedOptionValuePrice!
@@ -136,7 +144,8 @@ type CartItemSelectedOptionValuePrice {
 
 type SelectedGiftCardAmount {
     # Hash from the type of the option and value
-    id: ID!
+    id: ID! @deprecated(reason: "use uid")
+    uid: ID! @doc(description: "The unique ID of the selected option.")
     value: Money!
 }
 


### PR DESCRIPTION
## Problem

Schema has a lot of fields named id which doesn't align with the new naming convention.


## Solution

Updating all id fields to uid to be consistent with the new naming convention.


## Requested Reviewers

@melnikovi @prabhuram93 @DrewML 
