### PR TITLE
Enabling adding gift registrants while creating gift registry

### DIFF
--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -86,6 +86,7 @@ input CreateGiftRegistryInput {
     privacy_settings: GiftRegistryPrivacySettings!
     status: GiftRegistryStatus!
     shipping_address: GiftRegistryShippingAddressInput
+    registrants: [AddGiftRegistryRegistrantInput!]!
     dynamic_attributes: [GiftRegistryDynamicAttributeInput]
 }
 


### PR DESCRIPTION
## Problem

When creating gift registry, adding gift registrants are mandatory.

## Solution

Add an input field to support adding gift registrants

## Requested Reviewers
@melnikovi @cpartica @nrkapoor 

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
