### PR TITLE
Update the `schema.graphql` for additional output attributes

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/company.md
+++ b/design-documents/graph-ql/coverage/b2b/company.md
@@ -120,6 +120,7 @@ union CompanyStructureEntity = CompanyTeam | Customer
 type CompanyStructureItem @doc(description: "Company Team and Customer structure") {
     uid: ID! @doc(description: "ID of the item in the hierarchy")
     parent_id: ID @doc(description: "ID of the parent item in the hierarchy")
+    structure_id: ID! @doc(description: "ID of the company structure")
     entity: CompanyStructureEntity
 }
 
@@ -131,6 +132,7 @@ type CompanyTeam @doc(description: "Company Team entity output data schema.") {
     uid: ID! @doc(description: "Team id.")
     name: String @doc(description: "Team name.")
     description: String @doc(description: "Team description.")
+    structure_id: ID! @doc(description: "ID of the company structure")
 }
 
 input CompanyUsersFilterInput @doc(description: "Defines the input filters for a Company Users query") {
@@ -315,5 +317,6 @@ type Customer {
     team: CompanyTeam @doc(description: "Company User team data.")
     telephone: String @doc(description: "Company User phone number.")
     status: CompanyUserStatusEnum @doc(description: "Company User status.")
+    structure_id: ID! @doc(description: "ID of the company structure")
 }
 ```


### PR DESCRIPTION
## Problem

To add a new company team or company user into the existing company team (company user), a customer should transmit the encoded structure ID using attribute `target_id`. However, the user has no way to find out this data.

## Solution

Updating the schema.graphql with adding the output attribute `structure_id` into the types `CompanyStructureItem`, `CompanyTeam`, `Customer`. This solution gives a possibility to get the `structure_id` in responses of the mutations and queries.

## Requested Reviewers

@mauragcyrus @cpartica @prabhuram93 