### PR TITLE
Requisition list: align schema with uids and delete confirmation naming conventions

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
@@ -59,22 +59,38 @@ type RequistionListItems {
 interface RequisitionListItemInterface @doc(description: "Interface type for Requisition List Item") {
     uid: ID! @doc(description:"Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    qty: Float! @doc(description: "Quantity added")
+    quantity: Float! @doc(description: "Quantity added")
+    customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
 }
 
-type DefaultRequisitionListItem implements RequisitionListItemInterface
+type SimpleRequisitionListItem implements RequisitionListItemInterface
 @doc(description: "Requisition List Item Implementation that for Simple and Virtual Products") {
-    uid: ID! @doc(description: "Unique Identifier of Requisition List Item")
-    product: ProductInterface!
-    qty: Float! @doc(description:  "Quantity added")
-    customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
+}
+
+type GiftCardRequisitionListItem implements RequisitionListItemInterface
+@doc(description: "Requisition List Item Implementation that for GiftCard Products") {
+    gift_card_options: GiftCardOptions!
+}
+
+type GiftCardOptions {
+    sender_name: String
+    sender_email: String
+    recipient_name: String
+    recipient_email: String
+    amount: Money
+    custom_giftcard_amount: Money
+    message: String
+}
+
+type GroupedProductRequisitionListItem implements RequisitionListItemInterface {
+    grouped_products: [GroupedProductItem!]!
 }
 
 type DownloadableRequisitionListItem implements RequisitionListItemInterface
 @doc(description: "Requisition List Item Implementation that for Downloadable Products") {
     uid: ID! @doc(description: "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    qty: Float! @doc(description: "Quantity added")
+    quantity: Float! @doc(description: "Quantity added")
     customizable_options: [SelectedCustomizableOption] @doc(description:  "custom Option selected")
     links: [DownloadableProductLinks] @doc(description: "DownloadableProductLinks defines characteristics of a downloadable product")
     samples: [DownloadableProductSamples] @doc(description:  "DownloadableProductSamples defines characteristics of a downloadable product")
@@ -84,7 +100,7 @@ type BundleRequisitionListItem implements RequisitionListItemInterface
 @doc(description: "Requisition List Item Implementation that for Bundle Products") {
     uid: ID! @doc(description: "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    qty: Float! @doc(description: "Quantity added")
+    quantity: Float! @doc(description: "Quantity added")
     customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
     bundle_options: [SelectedBundleOption]! @doc(description: "selected bundle options")
 }
@@ -93,21 +109,19 @@ type ConfigurableRequisitionListItem implements RequisitionListItemInterface
 @doc(description: "Requisition List Item Implementation that for Configurable Products") {
     uid: ID! @doc(description:  "Unique Identifier of Requisition List Item")
     product: ProductInterface!
-    qty: Float! @doc(description: "Quantity added")
+    quantity: Float! @doc(description: "Quantity added")
     customizable_options: [SelectedCustomizableOption] @doc(description: "custom Option selected")
     configurable_options: [SelectedConfigurableOption] @doc(description: "Configurable options selected")
 }
 
 type Mutation {
     createRequisitionList(
-        name: String!, @doc(description: "name for the list")
-        description: String @doc(description: "description For the list")
+        input: CreateRequisitionListInput
     ): CreateRequisitionListOutput @doc(description: "Create Empty Requisition List")
 
     updateRequisitionList(
         requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
-        name: String!, @doc(description: "new name for list")
-        description: String @doc(description: "new description For the List")
+        input: UpdateRequisitionListInput
     ): UpdateRequisitionListOutput @doc(description: "Rename a requisition list and change description")
 
     deleteRequisitionList(
@@ -124,26 +138,21 @@ type Mutation {
         requisitionListItemUids: [ID!]! @doc(description: "unique Ids of Items to be deleted from requisition list")
     ): DeleteRequisitionListItemsOutput @doc(description: "Delete Items in requisition list")
 
-    updateRequisitionListItems(
-        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
-        items: [UpdateRequisitionListItemsInput!]! @doc(description: "Items to be updated from requisition list")
-    ): UpdateRequisitionListItemsOutput @doc(description: "Update Items in requisition list")
-
     addRequisitionListItemsToCart(
         requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
-        requisitionListItemUids: [ID!]! @doc(description: "selected requisition list items that are to be added")
+        requisitionListItemUids: [ID!] @doc(description: "selected requisition list items that are to be added. Not providing this parameter will all items from req. list to the cart")
     ): AddRequisitionListItemsToCartOutput @doc(description: "Add Requisition List Items To Customer Cart")
 
     copyItemsBetweenRequisitionLists(
         sourceRequisitionListUid: ID!, @doc(description: "unique Id of source requisition list")
         destinationRequisitionListUid: ID,  @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
-        requisitionListItemUids: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
+        requisitionListItem: CopyItemsBetweenRequisitionListsInput
     ): CopyItemsBetweenRequisitionListsOutput @doc(description: "Copy Items from Requisition List to another requisition list")
 
     moveItemsBetweenRequisitionLists(
         sourceRequisitionListUid: ID!, @doc(description: "unique Id of source requisition list")
         destinationRequisitionListUid: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
-        requisitionListItemUids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
+        requisitionListItem: MoveItemsBetweenRequisitionListsInput
     ): MoveItemsBetweenRequisitionListsOutput @doc(description: "Move Items from Requisition List to another requisition List")
 
     clearCustomerCart(
@@ -151,17 +160,35 @@ type Mutation {
     ): ClearCustomerCartOutput @doc(description: "Clears the cart items")
 }
 
+type CreateRequisitionListInput {
+    name: String! @doc(description: "name for the list")
+    description: String @doc(description: "description For the list")
+}
+
+type UpdateRequisitionListInput {
+    name: String! @doc(description: "new name for list")
+    description: String @doc(description: "new description For the List")
+}
+
+type CopyItemsBetweenRequisitionListsInput  {
+    requisitionListItemUids: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
+}
+
+type MoveItemsBetweenRequisitionListsInput  {
+    requisitionListItemUids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
+}
+
 type DeleteRequisitionListItemsOutput {
     status: Boolean!
-    list: RequisitionList
+    requisiton_list: RequisitionList
 }
 
 type UpdateRequisitionListItemsOutput {
-    list: RequisitionList
+    requisiton_list: RequisitionList
 }
 
 type AddProductsToRequisitionListOutput {
-    list: RequisitionList
+    requisiton_list: RequisitionList
 }
 
 input RequisitionListFilterInput {
@@ -171,8 +198,7 @@ input RequisitionListFilterInput {
 
 input RequisitionListItemsInput {
     sku: String!
-    quantity: Float
-    parent_sku: String
+    quantity: Float!
     selected_options: [ID!] @doc(description: "selected option ID")
     entered_options: [EnteredOptionInput!] @doc(description: "entered Options ID")
 }
@@ -185,11 +211,11 @@ input UpdateRequisitionListItemsInput {
 }
 
 type CreateRequisitionListOutput {
-    list: RequisitionList
+    requisiton_list: RequisitionList
 }
 
 type UpdateRequisitionListOutput {
-    list: RequisitionList
+    requisiton_list: RequisitionList
 }
 
 type DeleteRequisitionListOutput {
@@ -198,18 +224,32 @@ type DeleteRequisitionListOutput {
 }
 
 type AddRequisitionListItemsToCartOutput {
+    status: Boolean!
+    add_requisition_list_items_to_cart_user_errors: [AddRequisitionListItemToCartUserError]!
     cart: Cart # since requisition list is not mutated it is not part of the output
 }
 
+type AddRequisitionListItemToCartUserError {
+    message: String!
+    type: AddRequisitionListItemToCartUserErrorType!
+}
+
+enum AddRequisitionListItemToCartUserErrorType {
+    OUT_OF_STOCK
+    MAX_QTY_FOR_USER
+    NOT_AVAILABLE
+}
+
 type CopyItemsBetweenRequisitionListsOutput {
-    list: RequisitionList @doc(description:  "Destination Requisition List")# since source requisition list is not mutated it is not part of the output
+    requisiton_list: RequisitionList @doc(description:  "Destination Requisition List")# since source requisition list is not mutated it is not part of the output
 }
 
 type MoveItemsBetweenRequisitionListsOutput {
-    source: RequisitionList @doc(description:  "Source Requisition List")
-    destination: RequisitionList @doc(description: "Destination Requisition List")
+    source_requisiton_list: RequisitionList @doc(description:  "Source Requisition List")
+    destination_requisiton_list: RequisitionList @doc(description: "Destination Requisition List")
 }
 
 type ClearCustomerCartOutput {
+    status: Boolean!
     cart: Cart
 }

--- a/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
@@ -124,13 +124,18 @@ type Mutation {
         input: UpdateRequisitionListInput
     ): UpdateRequisitionListOutput @doc(description: "Rename a requisition list and change description")
 
+    updateRequisitionListItems(
+        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
+        requisitionListItems: [UpdateRequisitionListItemsInput!]! @doc(description: "Items to be updated from requisition list")
+    ): UpdateRequisitionListItemsOutput @doc(description: "Update Items in requisition list")
+
     deleteRequisitionList(
         requisitionListUid: ID! @doc(description: "unique Id of requisition list")
     ): DeleteRequisitionListOutput @doc(description: "Delete a requisition list with Id")
 
     addProductsToRequisitionList(
         requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
-        items: [RequisitionListItemsInput!]! @doc(description: "Products to be added to requisition list")
+        requisitionListItems: [RequisitionListItemsInput!]! @doc(description: "Products to be added to requisition list")
     ): AddProductsToRequisitionListOutput @doc(description: "Add items to requisition list")
 
     deleteRequisitionListItems(
@@ -156,7 +161,7 @@ type Mutation {
     ): MoveItemsBetweenRequisitionListsOutput @doc(description: "Move Items from Requisition List to another requisition List")
 
     clearCustomerCart(
-	    cartUid: String! @doc(description: "masked Cart Id")
+        cartUid: String! @doc(description: "masked Cart Id")
     ): ClearCustomerCartOutput @doc(description: "Clears the cart items")
 }
 
@@ -204,7 +209,6 @@ input RequisitionListItemsInput {
 }
 
 input UpdateRequisitionListItemsInput {
-    requisitionListItemUid: ID! @doc(description: "unique ID of Requisition List Item")
     selected_options: [ID!] @doc(description: "selected option ID")
     entered_options: [EnteredOptionInput!] @doc(description: "entered Options ID")
     quantity: Float

--- a/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
@@ -15,9 +15,9 @@
 #
 # 2. In requistion list view, `exportRequisitionList` query will generate a CSV file with particular requistion list data
 #
-# 3. In requistion list view, `renameRequistionList` mutatation can be used to rename the list
+# 3. In requistion list view, `updateRequistionList` mutatation can be used to update or rename the list
 #
-# 4. In requistion list view, one can edit items quantity, options etc or remove items with `deleteRequisitionListItems` and
+# 4. In requistion list view, one can edit items quantity, options etc or delete items with `deleteRequisitionListItems` and
 # `updateRequisitionListItems` mutation
 #
 # 5. In requistion list view, select requistion list items and move them , copy them to different requistion list with
@@ -122,7 +122,7 @@ type Mutation {
     deleteRequisitionListItems(
         requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
         requisitionListItemUids: [ID!]! @doc(description: "unique Ids of Items to be deleted from requisition list")
-    ): DeleteRequisitionListItemsOutput @doc(description: "Remove Items in requisition list")
+    ): DeleteRequisitionListItemsOutput @doc(description: "Delete Items in requisition list")
 
     updateRequisitionListItems(
         requisitionListUid: ID!, @doc(description: "unique Id of requisition list")

--- a/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/requisitionList.graphqls
@@ -17,7 +17,7 @@
 #
 # 3. In requistion list view, `renameRequistionList` mutatation can be used to rename the list
 #
-# 4. In requistion list view, one can edit items quantity, options etc or remove items with `removeRequisitionListItems` and
+# 4. In requistion list view, one can edit items quantity, options etc or remove items with `deleteRequisitionListItems` and
 # `updateRequisitionListItems` mutation
 #
 # 5. In requistion list view, select requistion list items and move them , copy them to different requistion list with
@@ -104,46 +104,46 @@ type Mutation {
         description: String @doc(description: "description For the list")
     ): CreateRequisitionListOutput @doc(description: "Create Empty Requisition List")
 
-    renameRequisitionList(
-        uid: ID!, @doc(description: "unique Id of requisition list")
+    updateRequisitionList(
+        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
         name: String!, @doc(description: "new name for list")
         description: String @doc(description: "new description For the List")
-    ): RenameRequisitionListOutput @doc(description: "Rename a requisition list and change description")
+    ): UpdateRequisitionListOutput @doc(description: "Rename a requisition list and change description")
 
     deleteRequisitionList(
-        uid: ID! @doc(description: "unique Id of requisition list")
+        requisitionListUid: ID! @doc(description: "unique Id of requisition list")
     ): DeleteRequisitionListOutput @doc(description: "Delete a requisition list with Id")
 
     addProductsToRequisitionList(
-        uid: ID!, @doc(description: "unique Id of requisition list")
+        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
         items: [RequisitionListItemsInput!]! @doc(description: "Products to be added to requisition list")
     ): AddProductsToRequisitionListOutput @doc(description: "Add items to requisition list")
 
-    removeRequisitionListItems(
-        uid: ID!, @doc(description: "unique Id of requisition list")
-        items: [ID!]! @doc(description: "unique Ids of Items to be removed from requisition list")
-    ): RemoveRequisitionListItemsOutput @doc(description: "Remove Items in requisition list")
+    deleteRequisitionListItems(
+        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
+        requisitionListItemUids: [ID!]! @doc(description: "unique Ids of Items to be deleted from requisition list")
+    ): DeleteRequisitionListItemsOutput @doc(description: "Remove Items in requisition list")
 
     updateRequisitionListItems(
-        uid: ID!, @doc(description: "unique Id of requisition list")
+        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
         items: [UpdateRequisitionListItemsInput!]! @doc(description: "Items to be updated from requisition list")
     ): UpdateRequisitionListItemsOutput @doc(description: "Update Items in requisition list")
 
     addRequisitionListItemsToCart(
-        listUid: ID!, @doc(description: "unique Id of requisition list")
-        itemUids: [ID!]! @doc(description: "selected requisition list items that are to be added")
+        requisitionListUid: ID!, @doc(description: "unique Id of requisition list")
+        requisitionListItemUids: [ID!]! @doc(description: "selected requisition list items that are to be added")
     ): AddRequisitionListItemsToCartOutput @doc(description: "Add Requisition List Items To Customer Cart")
 
     copyItemsBetweenRequisitionLists(
-        sourceUid: ID!, @doc(description: "unique Id of source requisition list")
-        destinationUid: ID,  @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
-        itemUids: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
+        sourceRequisitionListUid: ID!, @doc(description: "unique Id of source requisition list")
+        destinationRequisitionListUid: ID,  @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
+        requisitionListItemUids: [ID!]! @doc(description:  "selected requisition list items that are to be copied from source")
     ): CopyItemsBetweenRequisitionListsOutput @doc(description: "Copy Items from Requisition List to another requisition list")
 
     moveItemsBetweenRequisitionLists(
-        sourceUid: ID!, @doc(description: "unique Id of source requisition list")
-        destinationUid: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
-        itemUids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
+        sourceRequisitionListUid: ID!, @doc(description: "unique Id of source requisition list")
+        destinationRequisitionListUid: ID, @doc(description: "unique Id of destination requisition list") # If null new requisition list will be created
+        requisitionListItemUids: [ID!]! @doc(description: "selected requisition list items that are to be moved from source")
     ): MoveItemsBetweenRequisitionListsOutput @doc(description: "Move Items from Requisition List to another requisition List")
 
     clearCustomerCart(
@@ -151,20 +151,21 @@ type Mutation {
     ): ClearCustomerCartOutput @doc(description: "Clears the cart items")
 }
 
-type RemoveRequisitionListItemsOutput {
-    list : RequisitionList
+type DeleteRequisitionListItemsOutput {
+    status: Boolean!
+    list: RequisitionList
 }
 
 type UpdateRequisitionListItemsOutput {
-    list : RequisitionList
+    list: RequisitionList
 }
 
 type AddProductsToRequisitionListOutput {
-    list : RequisitionList
+    list: RequisitionList
 }
 
 input RequisitionListFilterInput {
-    uids: FilterEqualTypeInput, @doc(description: "Filter Customer Requisition lists with an requisition list ID or list of requisition list IDs")
+    requisitionListUid: FilterEqualTypeInput, @doc(description: "Filter Customer Requisition lists with an requisition list ID or list of requisition list IDs")
     name: FilterMatchTypeInput @doc(description: "Filter by display name of the Requisition list")
 }
 
@@ -172,13 +173,13 @@ input RequisitionListItemsInput {
     sku: String!
     quantity: Float
     parent_sku: String
-    selected_options: [String!] @doc(description: "selected option ID")
+    selected_options: [ID!] @doc(description: "selected option ID")
     entered_options: [EnteredOptionInput!] @doc(description: "entered Options ID")
 }
 
 input UpdateRequisitionListItemsInput {
-    item_id: ID! @doc(description: "unique ID of Requisition List Item")
-    selected_options: [String!] @doc(description: "selected option ID")
+    requisitionListItemUid: ID! @doc(description: "unique ID of Requisition List Item")
+    selected_options: [ID!] @doc(description: "selected option ID")
     entered_options: [EnteredOptionInput!] @doc(description: "entered Options ID")
     quantity: Float
 }
@@ -187,12 +188,13 @@ type CreateRequisitionListOutput {
     list: RequisitionList
 }
 
-type RenameRequisitionListOutput {
+type UpdateRequisitionListOutput {
     list: RequisitionList
 }
 
 type DeleteRequisitionListOutput {
-    requisition_list : RequisitionList
+    status: Boolean!
+    requisition_list: RequisitionList
 }
 
 type AddRequisitionListItemsToCartOutput {
@@ -200,12 +202,12 @@ type AddRequisitionListItemsToCartOutput {
 }
 
 type CopyItemsBetweenRequisitionListsOutput {
-    list : RequisitionList  @doc(description:  "Destination Requisition List")# since source requisition list is not mutated it is not part of the output
+    list: RequisitionList @doc(description:  "Destination Requisition List")# since source requisition list is not mutated it is not part of the output
 }
 
 type MoveItemsBetweenRequisitionListsOutput {
-    source : RequisitionList @doc(description:  "Source Requisition List")
-    destination : RequisitionList @doc(description: "Destination Requisition List")
+    source: RequisitionList @doc(description:  "Source Requisition List")
+    destination: RequisitionList @doc(description: "Destination Requisition List")
 }
 
 type ClearCustomerCartOutput {


### PR DESCRIPTION
## Problem
Schema changes to align uid naming and CRUD naming for Requisition lists.
Matching names with wishlist https://github.com/magento/architecture/pull/442
<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
Schema changes are added.
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
