### PR TITLE
We shouldn't give the possibility to update the registry's type.

### DIFF
--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -70,7 +70,6 @@ input UpdateGiftRegistryItemInput {
 
 input UpdateGiftRegistryInput {
     event_name: String
-    type_id: String
     message: String
     privacy_settings: GiftRegistryPrivacySettings
     status: GiftRegistryStatus


### PR DESCRIPTION
## Problem

The current schema doesn't follow the default Magento behavior on GiftRegistry updating.

![image](https://user-images.githubusercontent.com/15868188/98091662-62666880-1e8e-11eb-9218-7fbd826f55e7.png)

## Solution

We shouldn't have the possibility to update the registry's type.

## Requested Reviewers

@prabhuram93 @cpartica @nrkapoor 