### PR TITLE
Improvements to directory.graphqls to include more configation settings

### DIFF
--- a/design-documents/graph-ql/coverage/directory.graphqls
+++ b/design-documents/graph-ql/coverage/directory.graphqls
@@ -1,0 +1,39 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+type Query {
+    currency: Currency @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Currency") @doc(description: "The currency query returns information about store currency.") @cache(cacheable: false)
+    countries: [Country] @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Countries") @doc(description: "The countries query provides information for all countries.") @cache(cacheable: false)
+    country (id: String): Country @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Country") @doc(description: "The countries query provides information for a single country.") @cache(cacheable: false)
+}
+
+type Currency {
+    base_currency_code: String
+    base_currency_symbol: String
+    default_display_currecy_code: String @deprecated(reason: "Symbol was missed. Use `default_display_currency_code`.")
+    default_display_currency_code: String
+    default_display_currecy_symbol: String @deprecated(reason: "Symbol was missed. Use `default_display_currency_symbol`.")
+    default_display_currency_symbol: String
+    available_currency_codes: [String]
+    exchange_rates: [ExchangeRate]
+}
+
+type ExchangeRate {
+    currency_to: String
+    rate: Float
+}
+
+type Country {
+    id: String
+    two_letter_abbreviation: String
+    three_letter_abbreviation: String
+    full_name_locale: String
+    full_name_english: String
+    available_regions: [Region]
+}
+
+type Region {
+    id: Int
+    code: String
+    name: String
+}

--- a/design-documents/graph-ql/coverage/directory.graphqls
+++ b/design-documents/graph-ql/coverage/directory.graphqls
@@ -3,7 +3,7 @@
 
 type Query {
     currency: Currency @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Currency") @doc(description: "The currency query returns information about store currency.") @cache(cacheable: false)
-    countries: [Country] @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Countries") @doc(description: "The countries query provides information for all countries.") @cache(cacheable: false)
+    countries: [Country] @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Countries") @doc(description: "The countries query provides information for all countries. Sorted by Top Destination and locale specific country name.") @cache(cacheable: false)
     country (id: String): Country @resolver(class: "Magento\\DirectoryGraphQl\\Model\\Resolver\\Country") @doc(description: "The countries query provides information for a single country.") @cache(cacheable: false)
 }
 
@@ -25,15 +25,24 @@ type ExchangeRate {
 
 type Country {
     id: String
-    two_letter_abbreviation: String
-    three_letter_abbreviation: String
-    full_name_locale: String
-    full_name_english: String
-    available_regions: [Region]
+    two_letter_abbreviation: String @doc(description: "Country code according to ISO 3166-1 alpha-2")
+    three_letter_abbreviation: String @doc(description: "Country code according to ISO 3166-1 alpha-3") 
+    name: String @doc(description: "Name of the country in the locale of the current store") 
+    full_name_locale: String @deprecated(reason: "Use `name`") 
+    full_name_english: String @deprecated(reason: "Use `name`")
+    region_required: Boolean @doc(description: "Is a the region for this country") 
+    postcode_required: Boolean @doc(description: "Is a postcode required for this country") 
+    eu: Boolean @doc(description: "Country is a member of the European Union") 
+    available_regions: [Region] @doc(description: "Only returns regions if region_required StoreConfig.allow_optional_state is set. Sorted by localized name.") 
 }
 
 type Region {
     id: Int
-    code: String
-    name: String
+    code: String @doc(description: "Retuns the region code if a region has a code, else returns the non localized name") 
+    name: String @doc(description: "Locale specific region name.") 
+}
+
+type StoreConfig {
+    default_country: String @doc(description: "Default country used for country fields") 
+    allow_optional_state: String @doc(description: "Allow a customer to enter a state when it isn't required for a country") 
 }


### PR DESCRIPTION
## Problem

To build proper customer address forms, we need to have some additional information.

## Solution

I've split this PR in two commits, the first is a copy of the current schema in the magento repository, the second are my modifications on it: https://github.com/magento/architecture/commit/5c8ab137d02c8b36a0d063d56883bdf743e5f3c2

Introduce additional country fields:

- add field to `Country` type: `region_required`
- add field to `Country` type: `postcode_required`
- add field to `Country` type: `name`
- add field to `Country` type: `eu`
- deprecate `full_name_locale` in favor of `name`
- deprecate `full_name_english` in favor of `name`
- add field to `StoreConfig` type: `default_country`
- add field to `StoreConfig` type: `allow_optional_state`
- adds field docs with sorting information: This should be a nice quality of life improvement for the frontend implementor so they don't have to do this on the frontend.

## Requested Reviewers

@buskamuza Taggin you because you seem to be responsible for this component
@cpartica Tagging you of the discussion on Slack
