### PR TITLE
Customer reorder UID Changes.

### DIFF
--- a/design-documents/graph-ql/coverage/customer/customer-reorder.graphqls
+++ b/design-documents/graph-ql/coverage/customer/customer-reorder.graphqls
@@ -1,5 +1,5 @@
 type Mutation {
-    reorderItems(orderId: ID!): ReorderItemsOutput! @doc(description: "Add all items from the registered customer's order to his shopping cart.")
+    reorderItems(orderUid: ID!): ReorderItemsOutput! @doc(description: "Add all items from the registered customer's order to his shopping cart.")
 }
 
 # For errors in queries we can rely on the specification and its implementation in Webonyx:


### PR DESCRIPTION
## Problem

Customer Reorder Schema needs to update id with UID changes.

## Solution

With consistency throughout the graphql schema, we have replaced the Id field with Uid.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
