### PR TITLE
Reward points Uid changes

### DIFF
--- a/design-documents/graph-ql/coverage/customer/reward-points.graphqls
+++ b/design-documents/graph-ql/coverage/customer/reward-points.graphqls
@@ -7,8 +7,8 @@ type Cart {
 }
 
 type Mutation {
-    applyRewardPointsToCart(cartId: ID!): ApplyRewardPointsToCartOutput @doc(description: "Apply all available points up to the cart total. Partial redemption is not available")
-    removeRewardPointsFromCart(cartId: ID!): RemoveRewardPointsFromCartOutput @doc(description: "Cancel usage of the previously applied reward points to cart")
+    applyRewardPointsToCart(cartUid: ID!): ApplyRewardPointsToCartOutput @doc(description: "Apply all available points up to the cart total. Partial redemption is not available")
+    removeRewardPointsFromCart(cartUid: ID!): RemoveRewardPointsFromCartOutput @doc(description: "Cancel usage of the previously applied reward points to cart")
 }
 
 type ApplyRewardPointsToCartOutput {


### PR DESCRIPTION
## Problem

Customer Reward Points UID Changes in the schema file.

## Solution

To keep consistency throughout the GraphQL schema, we have replaced the Id field with Uid.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
