### PR TITLE
Customer Newsletter subscription label changes.

### DIFF
--- a/design-documents/graph-ql/coverage/customer/SubscribeEmailToNewsletter.graphqls
+++ b/design-documents/graph-ql/coverage/customer/SubscribeEmailToNewsletter.graphqls
@@ -3,7 +3,7 @@ type Mutation {
 }
 
 type SubscribeEmailToNewsletterOutput {
-    status: SubscriptionStatusesEnum @doc(description: "Returns a status of subscription")
+    status: SubscriptionStatusesEnum @doc(description: "Returns a status of newsletter subscription")
 }
 
 enum SubscriptionStatusesEnum {


### PR DESCRIPTION
## Problem

Customer Newsletter Subscription label changes.

## Solution

Just add the Newsletter keyword before subscription. The label will be clear for the subscription to the newsletter.
## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
