### PR TITLE
PWA-1486: Define the schema for FPT cart item prices

### DIFF
--- a/design-documents/graph-ql/coverage/quote.graphqls
+++ b/design-documents/graph-ql/coverage/quote.graphqls
@@ -367,7 +367,8 @@ type Discount @doc(description:"Defines an individual discount. A discount can b
 }
 
 type CartItemPrices {
-    price: Money!
+    price: Money! @doc(description:"Item price that might include tax depending on display settings for cart")
+    fixed_product_taxes: [FixedProductTax] @doc(description:"Applied FPT to the cart item")
     row_total: Money!
     row_total_including_tax: Money!
     discounts: [Discount] @doc(description:"An array of discounts to be applied to the cart item")


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
Applicable FPT doesn't show in GraphQL on cart Item prices after an address has been set.

STEPS TO REPLICATE:

Enable FixedProductTax following documentation https://docs.magento.com/user-guide/tax/fixed-product-tax-configuration.html
Create product FPT attribute
Assign it to appropriate Attribute sets
Create test product having FPT sku and FPT attribute created before as property
Assign FPT to Texas or another state on the FPT property related to US country
Create cart by GraphQL
Set Shipping Address to cart by GraphQL
Add the product to cart by GraphQL
Query the cart by GraphQL

ACTUAL RESULTS

"fixed_product_taxes" empty in the response, screenshot attached

## Solution
We need a field on cart Item prices and not on Product Interface which shows all FPTs for all states which is not very helpful.

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
