### PR TITLE
PWA-1487: additional schema definition for routable interface

### DIFF
--- a/design-documents/graph-ql/coverage/routing/storefront-route.md
+++ b/design-documents/graph-ql/coverage/routing/storefront-route.md
@@ -68,7 +68,10 @@ Since the entity type is built in to GraphQL introspection, `RoutableInterface` 
 
 ```graphql
 interface RoutableInterface {
-  display_metadata: String
+    #copied from the deprecated EntityUrl type which will not be used anymore
+    relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
+    redirectCode: Int @doc(description: "301 or 302 HTTP code for url permanent or temporary redirect or 0 for the 200 no redirect")
+    display_metadata: String
 }
 ```
 
@@ -90,7 +93,7 @@ type CmsPage implements RoutableInterface {
 # multiple interfaces
 type SimpleProduct implements ProductInterface & RoutableInterface {
   # [...other property definitions]
-  display_metadata: String
+  display_metadata: String # not to be confused with meta_description, meta_keywords, meta_title which is defined in each entity like cms
 }
 ```
 
@@ -100,6 +103,7 @@ To enable clients to query based on route, add a root query to the schema.
 
 ```graphql
 type Query {
+    urlResolver(url: String!): EntityUrl @deprecated(reason: "Use `route` instead")
     route(url: String!): RoutableInterface
 }
 ```


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
By deprecating urlResolver we need to make sure that we can get the same data from Routable Interface
It turns out that we're missing some basic functionality that urlResolver provided, and it's not provided through Routable Interface

## Solution

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->
We need to add to Routable Interface two fields: relative_url and redirectCode to know if the requested URL was a redirect or not as it contains code useful for SEO, like permanent or temporary redirect.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
