### PR TITLE
Adding nodes to Magento schema

### DIFF
--- a/design-documents/graph-ql/coverage/nodes.graphqls
+++ b/design-documents/graph-ql/coverage/nodes.graphqls
@@ -1,0 +1,41 @@
+type Query {
+    #initially we have to still support numeric ids
+    node(id: Int & uid: ID): Node
+}
+
+interface NodeInterface {
+    uid: ID! @doc(description: "The unique ID for a `Node")
+}
+
+type Node implements NodeInterface {
+    # inherits uid: ID! @doc(description: "The unique ID for a `Node")
+}
+
+#adding to every product type a node interface
+type SimpleProduct implements ProductInterface & NodeInterface & PhysicalProductInterface & CustomizableProductInterface {
+}
+
+type VirtualProduct implements ProductInterface & NodeInterface & CustomizableProductInterface {
+}
+
+#adding to every product type a node interface & also look for additional modules
+type ConfigurableProduct implements ProductInterface & NodeInterface & PhysicalProductInterface & CustomizableProductInterface {
+}
+
+type BundleProduct implements ProductInterface & NodeInterface & PhysicalProductInterface & CustomizableProductInterface {
+}
+
+type DownloadableProduct implements ProductInterface & NodeInterface & CustomizableProductInterface {
+}
+
+type GroupedProduct implements ProductInterface & NodeInterface & PhysicalProductInterface {
+}
+
+type GiftCardProduct implements ProductInterface & PhysicalProductInterface & CustomizableProductInterface {
+}
+
+type CategoryTree implements CategoryInterface & NodeInterface {
+}
+
+type CmsPage implements NodeInterface {
+}

--- a/design-documents/graph-ql/nodes.md
+++ b/design-documents/graph-ql/nodes.md
@@ -1,0 +1,39 @@
+# GraphQL Nodes - Global Object Identification
+
+To provide options for GraphQL clients to elegantly handle caching and data refetching, GraphQL servers need to expose object identifiers in a standardized way.
+
+For this to work, a client will need to query via a standard mechanism to request an object by ID. Then, in the response, the schema will need to provide a standard way of providing these IDs.
+
+Example
+```graphql
+{
+  node(uid: "MTM0MzQ=") {
+    id
+    ... on SimpleProduct {
+      name
+      uid
+    }
+    ... on CategoryTree {
+      name
+      children
+    }
+  }
+}
+```
+
+Nodes IDs should be unique throughout the entire schema and ideally for every store since store code is unique
+
+To implement this the uid has to be composed out of:
+```
+base64Encode("StoreCode/__typeName/id")
+```
+
+This way we can know what is the type requested and render it to the actual type.
+It will help our schema to be more compliant as all entities should be nodes.
+
+More information in the Graphql Spec
+- [https://graphql.org/learn/global-object-identification/](https://graphql.org/learn/global-object-identification/)
+
+
+Schema implementation
+- [nodes.graphqls](coverage/nodes.graphqls)


### PR DESCRIPTION
## Problem

There's no way to grab an object by ID. We need a global way to do this and graphql spec is the answer.

## Solution

Add a node and NodeInterface to solve consistent object access enables simple caching and object lookups 
See [Global Object Identification](https://graphql.org/learn/global-object-identification/)

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
