### PR TITLE
[GQL gift registry] cart management mutations

### DIFF
--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -130,12 +130,12 @@ input GiftRegistryDynamicAttributeInput {
     value: String!
 }
 
-interface GiftRegistryUserErrors {
+interface GiftRegistryUserErrorsInterface {
     status: Boolean!
     user_errors: [GiftRegistryItemsUserError]!
 }
 
-interface GiftRegistryItemUserError {
+interface GiftRegistryItemUserErrorInterface {
     status: Boolean!
     user_errors: GiftRegistryItemsUserError
 }
@@ -154,10 +154,10 @@ type RemoveGiftRegistryOutput {
     is_removed: Boolean!
 }
 
-type AddGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserError {
+type AddGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {
 }
 
-type MoveCartItemsToGiftRegistryOutput implements GiftRegistryOutputInterface, GiftRegistryUserErrors {
+type MoveCartItemsToGiftRegistryOutput implements GiftRegistryOutputInterface, GiftRegistryUserErrorsInterface {
 }
 
 type GiftRegistryItemsUserError {
@@ -173,10 +173,10 @@ enum GiftRegistryItemsUserErrorType {
     UNDEFINED @doc(description: "Used for other exceptions like db connection failures or others")
 }
 
-type RemoveGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserError {
+type RemoveGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {
 }
 
-type UpdateGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserError {
+type UpdateGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {
 }
 
 type AddGiftRegistryRegistrantsOutput implements GiftRegistryOutputInterface {

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -26,7 +26,7 @@ type Mutation {
     updateGiftRegistry(giftRegistryUid: ID!, giftRegistry: UpdateGiftRegistryInput!): UpdateGiftRegistryOutput
     removeGiftRegistry(giftRegistryUid: ID!): RemoveGiftRegistryOutput
 
-    addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput @deprecated(reason: "Use `moveCartItemsToGiftRegistry` instead. Not supported for gift registry") @doc(description: "Adds individual items to the gift registry")
+    addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput @doc(description: "Adds individual items to the gift registry")
     moveCartItemsToGiftRegistry(cartUid: ID!, giftRegistryUid: ID!): MoveCartItemsToGiftRegistryOutput @doc(description: "Moves all items items from cart to the gift registry")
 
     removeGiftRegistryItems(giftRegistryUid: ID!, itemUids: [ID!]!): RemoveGiftRegistryItemsOutput
@@ -79,7 +79,7 @@ input EnteredOptionInput {
 }
 
 input UpdateGiftRegistryItemInput {
-    giftRegistryItemUid: ID!
+    gift_registry_item_uid: ID!
     quantity: Float!
     note: String
 }
@@ -94,10 +94,9 @@ input UpdateGiftRegistryInput {
 }
 
 input CreateGiftRegistryInput {
-    giftRegistryUid: ID @deprecated(reason: "Use `gift_registry_uid` instead") @doc(description: "Optional uid, can be generated on the client and used for sending multiple gift-registry related mutations in a single request. For example, create registry and immediatly add items or registrants.")
-    gift_registry_uid: ID
+    gift_registry_uid: ID @doc(description: "Optional uid, can be generated on the client and used for sending multiple gift-registry related mutations in a single request. For example, create registry and immediatly add items or registrants.")
     event_name: String!
-    giftRegistryTypeUid: ID!
+    gift_registry_type_uid: ID!
     message: String!
     privacy_settings: GiftRegistryPrivacySettings!
     status: GiftRegistryStatus!
@@ -112,7 +111,6 @@ input GiftRegistryShippingAddressInput @doc(description: "Either address data or
 }
 
 input UpdateGiftRegistryRegistrantInput {
-    giftRegistryRegistrantUid: ID! @deprecated(reason: "Use `gift_registry_registrant_uid` instead")
     gift_registry_registrant_uid: ID
     first_name: String
     last_name: String
@@ -137,49 +135,63 @@ interface GiftRegistryUserErrors {
     gift_registry_user_errors: [GiftRegistryItemsUserError]!
 }
 
-type CreateGiftRegistryOutput {
+
+interface GiftRegistryUserErrors {
+    status: Boolean!
+    gift_registry_user_errors: [GiftRegistryItemsUserError]!
+}
+
+interface GiftRegistryItemUserError {
+    status: Boolean!
+    gift_registry_user_errors: GiftRegistryItemsUserError
+}
+
+interface GiftRegistryOutputInterface {
     gift_registry: GiftRegistry
 }
 
-type UpdateGiftRegistryOutput {
-    gift_registry: GiftRegistry
+type CreateGiftRegistryOutput implements GiftRegistryOutputInterface {
+}
+
+type UpdateGiftRegistryOutput implements GiftRegistryOutputInterface  {
 }
 
 type RemoveGiftRegistryOutput {
     is_removed: Boolean!
 }
 
-type AddGiftRegistryItemsOutput {
-    gift_registry: GiftRegistry
+type AddGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserError {
 }
 
-type MoveCartItemsToGiftRegistryOutput implements GiftRegistryUserErrors {
-    gift_registry: GiftRegistry
+type MoveCartItemsToGiftRegistryOutput implements GiftRegistryOutputInterface, GiftRegistryUserErrors {
 }
 
-enum GiftRegistryItemsUserError {
+type GiftRegistryItemsUserError {
+    message: String!
+    product_uid: ID
+    gift_registry_item_uid: ID
+    code: GiftRegistryItemsUserErrorType!
+}
+
+enum GiftRegistryItemsUserErrorType {
     OUT_OF_STOCK
     NOT_AVAILABLE
+    UNDEFINED @doc(description: "Used for other exceptions like db connection failures or others")
 }
 
-type RemoveGiftRegistryItemsOutput {
-    gift_registry: GiftRegistry
+type RemoveGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserError {
 }
 
-type UpdateGiftRegistryItemsOutput implements GiftRegistryUserErrors {
-    gift_registry: GiftRegistry
+type UpdateGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserError {
 }
 
-type AddGiftRegistryRegistrantsOutput {
-    gift_registry: GiftRegistry
+type AddGiftRegistryRegistrantsOutput implements GiftRegistryOutputInterface {
 }
 
-type UpdateGiftRegistryRegistrantsOutput {
-    gift_registry: GiftRegistry
+type UpdateGiftRegistryRegistrantsOutput implements GiftRegistryOutputInterface {
 }
 
-type RemoveGiftRegistryRegistrantsOutput {
-    gift_registry: GiftRegistry
+type RemoveGiftRegistryRegistrantsOutput implements GiftRegistryOutputInterface {
 }
 
 type ShareGiftRegistryOutput {

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -163,10 +163,10 @@ type GiftRegistryItemError {
     product_uid: ID
     gift_registry_item_uid: ID
     gift_registry_uid: ID
-    code: GiftRegistryItemsErrorType!
+    code: GiftRegistryItemErrorType!
 }
 
-enum GiftRegistryItemsErrorType {
+enum GiftRegistryItemErrorType {
     OUT_OF_STOCK
     NOT_FOUND @doc(description: "Used for exceptions like EntityNotFound")
     UNDEFINED @doc(description: "Used for other exceptions like db connection failures or other exceptions")

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -9,7 +9,7 @@ type Query {
         email: String! @doc(description: "The registrant's email")
     ): [GiftRegistrySearchResult] @doc(description: "Search for gift registries by specifying a registrant email address")
     giftRegistryIdSearch(
-        giftRegistryUid: String! @doc(description: "The ID of the gift registry")
+        giftRegistryUid: ID! @doc(description: "The ID of the gift registry")
     ): [GiftRegistrySearchResult] @doc(description: "Search for gift registries by specifying a registry URL key")
     giftRegistryTypeSearch(
         firstName: String! @doc(description: "The first name of the registrant")
@@ -26,7 +26,10 @@ type Mutation {
     updateGiftRegistry(giftRegistryUid: ID!, giftRegistry: UpdateGiftRegistryInput!): UpdateGiftRegistryOutput
     removeGiftRegistry(giftRegistryUid: ID!): RemoveGiftRegistryOutput
 
-    addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput
+    addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput @doc(description: "Adds individual items to the gift registry")
+    addGiftRegistryItemsFromCart(giftRegistryUid: ID!, cartUid: ID!, emptyCart: Boolean = true): AddGiftRegistryItemsFromCartOutput @doc(description: "Adds the whole cart with all items to the gift registry with option to empty the cart")
+    moveCartItemsToGiftRegistry(cartUid: ID!, giftRegistryUid: ID!): MoveCartItemsToGiftRegistryOutput @doc(description: "Moves all items items from cart to the gift registry")
+
     removeGiftRegistryItems(giftRegistryUid: ID!, itemUids: [ID!]!): RemoveGiftRegistryItemsOutput
     updateGiftRegistryItems(giftRegistryUid: ID!, items: [UpdateGiftRegistryItemInput!]!): UpdateGiftRegistryItemsOutput
 
@@ -92,7 +95,8 @@ input UpdateGiftRegistryInput {
 }
 
 input CreateGiftRegistryInput {
-    giftRegistryUid: ID @doc(description: "Optional uid, can be generated on the client and used for sending multiple gift-registry related mutations in a single request. For example, create registry and immediatly add items or registrants.")
+    giftRegistryUid: ID @deprecated(reason: "Use `gift_registry_uid` instead") @doc(description: "Optional uid, can be generated on the client and used for sending multiple gift-registry related mutations in a single request. For example, create registry and immediatly add items or registrants.")
+    gift_registry_uid: ID
     event_name: String!
     giftRegistryTypeUid: ID!
     message: String!
@@ -109,7 +113,8 @@ input GiftRegistryShippingAddressInput @doc(description: "Either address data or
 }
 
 input UpdateGiftRegistryRegistrantInput {
-    giftRegistryRegistrantUid: ID!
+    giftRegistryRegistrantUid: ID! @deprecated(reason: "Use `gift_registry_registrant_uid` instead")
+    gift_registry_registrant_uid: ID
     first_name: String
     last_name: String
     email: String
@@ -129,26 +134,55 @@ input GiftRegistryDynamicAttributeInput {
 }
 
 type CreateGiftRegistryOutput {
+    status: Boolean!
+    create_gift_registry_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
 type UpdateGiftRegistryOutput {
+    status: Boolean!
+    update_gift_registry_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
 type RemoveGiftRegistryOutput {
+    status: Boolean!
+    remove_gift_registry_user_errors: [GiftRegistryItemsUserError]!
     is_removed: Boolean!
 }
 
 type AddGiftRegistryItemsOutput {
+    status: Boolean!
+    add_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
+type MoveCartItemsToGiftRegistryOutput {
+    status: Boolean!
+    move_cart_items_to_gift_registry_user_errors: [GiftRegistryItemsUserError]!
+    gift_registry: GiftRegistry
+}
+
+type AddGiftRegistryItemsFromCartOutput {
+    status: Boolean!
+    add_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
+    gift_registry: GiftRegistry
+}
+
+enum GiftRegistryItemsUserError {
+    OUT_OF_STOCK
+    NOT_AVAILABLE
+}
+
 type RemoveGiftRegistryItemsOutput {
+    status: Boolean!
+    remove_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
 type UpdateGiftRegistryItemsOutput {
+    status: Boolean!
+    update_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -131,11 +131,11 @@ input GiftRegistryDynamicAttributeInput {
 }
 
 interface GiftRegistryErrorsInterface {
-    errors: [GiftRegistryItemUserError]!
+    errors: [GiftRegistryItemError]!
 }
 
 interface GiftRegistryItemErrorInterface {
-    error: GiftRegistryItemUserError
+    error: GiftRegistryItemError
 }
 
 interface GiftRegistryOutputInterface {
@@ -158,15 +158,15 @@ type AddGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegi
 type MoveCartItemsToGiftRegistryOutput implements GiftRegistryOutputInterface, GiftRegistryErrorsInterface {
 }
 
-type GiftRegistryItemUserError {
+type GiftRegistryItemError {
     message: String!
     product_uid: ID
     gift_registry_item_uid: ID
     gift_registry_uid: ID
-    code: GiftRegistryItemsUserErrorType!
+    code: GiftRegistryItemsErrorType!
 }
 
-enum GiftRegistryItemsUserErrorType {
+enum GiftRegistryItemsErrorType {
     OUT_OF_STOCK
     NOT_FOUND @doc(description: "Used for exceptions like EntityNotFound")
     UNDEFINED @doc(description: "Used for other exceptions like db connection failures or other exceptions")

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -164,6 +164,7 @@ type GiftRegistryItemsUserError {
     message: String!
     product_uid: ID
     gift_registry_item_uid: ID
+    gift_registry_uid: ID
     code: GiftRegistryItemsUserErrorType!
 }
 

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -132,18 +132,12 @@ input GiftRegistryDynamicAttributeInput {
 
 interface GiftRegistryUserErrors {
     status: Boolean!
-    gift_registry_user_errors: [GiftRegistryItemsUserError]!
-}
-
-
-interface GiftRegistryUserErrors {
-    status: Boolean!
-    gift_registry_user_errors: [GiftRegistryItemsUserError]!
+    user_errors: [GiftRegistryItemsUserError]!
 }
 
 interface GiftRegistryItemUserError {
     status: Boolean!
-    gift_registry_user_errors: GiftRegistryItemsUserError
+    user_errors: GiftRegistryItemsUserError
 }
 
 interface GiftRegistryOutputInterface {

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -27,7 +27,7 @@ type Mutation {
     removeGiftRegistry(giftRegistryUid: ID!): RemoveGiftRegistryOutput
 
     addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput @doc(description: "Adds individual items to the gift registry")
-    moveCartItemsToGiftRegistry(cartUid: ID!, giftRegistryUid: ID!): MoveCartItemsToGiftRegistryOutput @doc(description: "Moves all items items from cart to the gift registry")
+    moveCartItemsToGiftRegistry(cartUid: ID!, giftRegistryUid: ID!): MoveCartItemsToGiftRegistryOutput @doc(description: "Moves all items from cart to the gift registry")
 
     removeGiftRegistryItems(giftRegistryUid: ID!, itemUids: [ID!]!): RemoveGiftRegistryItemsOutput
     updateGiftRegistryItems(giftRegistryUid: ID!, items: [UpdateGiftRegistryItemInput!]!): UpdateGiftRegistryItemsOutput
@@ -130,14 +130,12 @@ input GiftRegistryDynamicAttributeInput {
     value: String!
 }
 
-interface GiftRegistryUserErrorsInterface {
-    status: Boolean!
-    user_errors: [GiftRegistryItemsUserError]!
+interface GiftRegistryErrorsInterface {
+    errors: [GiftRegistryItemUserError]!
 }
 
-interface GiftRegistryItemUserErrorInterface {
-    status: Boolean!
-    user_errors: GiftRegistryItemsUserError
+interface GiftRegistryItemErrorInterface {
+    error: GiftRegistryItemUserError
 }
 
 interface GiftRegistryOutputInterface {
@@ -154,13 +152,13 @@ type RemoveGiftRegistryOutput {
     is_removed: Boolean!
 }
 
-type AddGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {
+type AddGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemErrorInterface {
 }
 
-type MoveCartItemsToGiftRegistryOutput implements GiftRegistryOutputInterface, GiftRegistryUserErrorsInterface {
+type MoveCartItemsToGiftRegistryOutput implements GiftRegistryOutputInterface, GiftRegistryErrorsInterface {
 }
 
-type GiftRegistryItemsUserError {
+type GiftRegistryItemUserError {
     message: String!
     product_uid: ID
     gift_registry_item_uid: ID
@@ -174,10 +172,10 @@ enum GiftRegistryItemsUserErrorType {
     UNDEFINED @doc(description: "Used for other exceptions like db connection failures or other exceptions")
 }
 
-type RemoveGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {
+type RemoveGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemErrorInterface {
 }
 
-type UpdateGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {
+type UpdateGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemErrorInterface {
 }
 
 type AddGiftRegistryRegistrantsOutput implements GiftRegistryOutputInterface {

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -170,8 +170,8 @@ type GiftRegistryItemsUserError {
 
 enum GiftRegistryItemsUserErrorType {
     OUT_OF_STOCK
-    NOT_AVAILABLE
-    UNDEFINED @doc(description: "Used for other exceptions like db connection failures or others")
+    NOT_FOUND @doc(description: "Used for exceptions like EntityNotFound")
+    UNDEFINED @doc(description: "Used for other exceptions like db connection failures or other exceptions")
 }
 
 type RemoveGiftRegistryItemsOutput implements GiftRegistryOutputInterface, GiftRegistryItemUserErrorInterface {

--- a/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
+++ b/design-documents/graph-ql/coverage/customer/gift-registry.graphqls
@@ -26,8 +26,7 @@ type Mutation {
     updateGiftRegistry(giftRegistryUid: ID!, giftRegistry: UpdateGiftRegistryInput!): UpdateGiftRegistryOutput
     removeGiftRegistry(giftRegistryUid: ID!): RemoveGiftRegistryOutput
 
-    addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput @doc(description: "Adds individual items to the gift registry")
-    addGiftRegistryItemsFromCart(giftRegistryUid: ID!, cartUid: ID!, emptyCart: Boolean = true): AddGiftRegistryItemsFromCartOutput @doc(description: "Adds the whole cart with all items to the gift registry with option to empty the cart")
+    addGiftRegistryItems(giftRegistryUid: ID!, items: [AddGiftRegistryItemInput!]!): AddGiftRegistryItemsOutput @deprecated(reason: "Use `moveCartItemsToGiftRegistry` instead. Not supported for gift registry") @doc(description: "Adds individual items to the gift registry")
     moveCartItemsToGiftRegistry(cartUid: ID!, giftRegistryUid: ID!): MoveCartItemsToGiftRegistryOutput @doc(description: "Moves all items items from cart to the gift registry")
 
     removeGiftRegistryItems(giftRegistryUid: ID!, itemUids: [ID!]!): RemoveGiftRegistryItemsOutput
@@ -133,39 +132,28 @@ input GiftRegistryDynamicAttributeInput {
     value: String!
 }
 
-type CreateGiftRegistryOutput {
+interface GiftRegistryUserErrors {
     status: Boolean!
-    create_gift_registry_user_errors: [GiftRegistryItemsUserError]!
+    gift_registry_user_errors: [GiftRegistryItemsUserError]!
+}
+
+type CreateGiftRegistryOutput {
     gift_registry: GiftRegistry
 }
 
 type UpdateGiftRegistryOutput {
-    status: Boolean!
-    update_gift_registry_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
 type RemoveGiftRegistryOutput {
-    status: Boolean!
-    remove_gift_registry_user_errors: [GiftRegistryItemsUserError]!
     is_removed: Boolean!
 }
 
 type AddGiftRegistryItemsOutput {
-    status: Boolean!
-    add_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
-type MoveCartItemsToGiftRegistryOutput {
-    status: Boolean!
-    move_cart_items_to_gift_registry_user_errors: [GiftRegistryItemsUserError]!
-    gift_registry: GiftRegistry
-}
-
-type AddGiftRegistryItemsFromCartOutput {
-    status: Boolean!
-    add_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
+type MoveCartItemsToGiftRegistryOutput implements GiftRegistryUserErrors {
     gift_registry: GiftRegistry
 }
 
@@ -175,14 +163,10 @@ enum GiftRegistryItemsUserError {
 }
 
 type RemoveGiftRegistryItemsOutput {
-    status: Boolean!
-    remove_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
     gift_registry: GiftRegistry
 }
 
-type UpdateGiftRegistryItemsOutput {
-    status: Boolean!
-    update_gift_registry_items_user_errors: [GiftRegistryItemsUserError]!
+type UpdateGiftRegistryItemsOutput implements GiftRegistryUserErrors {
     gift_registry: GiftRegistry
 }
 

--- a/design-documents/graph-ql/directives.graphqls
+++ b/design-documents/graph-ql/directives.graphqls
@@ -1,0 +1,39 @@
+directive @doc(description: String="") on QUERY
+    | MUTATION
+    | FIELD
+    | FRAGMENT_DEFINITION
+    | FRAGMENT_SPREAD
+    | INLINE_FRAGMENT
+    | SCHEMA
+    | SCALAR
+    | OBJECT
+    | FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+
+directive @resolver(class: String="") on QUERY
+    | MUTATION
+    | FIELD
+    | FRAGMENT_DEFINITION
+    | FRAGMENT_SPREAD
+    | INLINE_FRAGMENT
+    | SCHEMA
+    | SCALAR
+    | OBJECT
+    | FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+
+directive @typeResolver(class: String="") on UNION
+    | INTERFACE
+    | OBJECT
+
+directive @cache(cacheIdentity: String="" cacheable: Boolean=true) on QUERY


### PR DESCRIPTION

## Problem
Luma has this operation to add all items from cart to gift registry. We don't have this in graphql.
Not only that we don't have it yet, but we have opened a lot of use cases by adding individual items to gift-registry, which we don't want to support just yet.
<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
Add specialized query to move items to cart to gift registry. Alternatively we could use this query to empty the cart while doing so or not.
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
