### PR TITLE
X vary cache proposal

### DIFF
--- a/design-documents/graph-ql/improved-caching.md
+++ b/design-documents/graph-ql/improved-caching.md
@@ -40,7 +40,7 @@ Vary: Accept-Encoding, Cookie
 
 All components/headers that compose cache key should be included in the Vary.
 
-## Solution
+## The Solution
 Graphql would compute the cache key and return a header with the same function as the Luma cookie (`X-Magento-Vary`), except we won't name it that way. The `Vary` header is not meant to have a hash.
 ````
 X-Magento-Request-Id: 85a0b196524c60eaeb7c87d1aa4708a3fb20c6a1
@@ -63,4 +63,5 @@ The `X-Magento-Request-Id` will take into account `X-Magento-Request-Id` and res
 Vary: X-Magento-Request-Id
 ````
 
-This is all we need. we don't need to add Store and Content-Currency to Vary anymore, though if we want to be transparent for the public headers we still can.
+This should suffice all explained. We don't need to add Store and Content-Currency to Vary anymore, though if we want to be transparent for the public headers we still can.
+For FPC built in cache there would be no changes besides outputing X-Magento-Request-Id and the proper Vary. We already have the code that computes the cookie hash value.

--- a/design-documents/graph-ql/improved-caching.md
+++ b/design-documents/graph-ql/improved-caching.md
@@ -1,0 +1,66 @@
+## Current caching
+Like described in [dev docs](https://devdocs.magento.com/guides/v2.4/graphql/caching.html) we create a full query cache which we identify through a unique key
+
+The unique cache key is usually a hash based on several factors which define the type of request, scope etc.
+
+Currently that formula is:
+
+````
+hash([FULL URL + GET PARAMS] + [Store Header Value] + [Content-Currency Header Value])
+````
+
+All three types  of cache (FPC, Varnish and Fastly) now know about those headers and they compute different caches
+
+## The problem
+This strategy only supposes that all components of cache have public values, and knowing their values doesn't pose any security concern.
+There is however what we can call private data that should not really be exposed or at the very least guessed easily if exposed.
+
+Take customer-group as an example. At no point in Luma would we expose customer group. Instead we compute the same hash but including customer group and salt it:
+
+````
+hash([FULL URL + GET PARAMS] + [Store] + [Currency] + [CustomerGroup] + [Salt])
+````
+
+This works In Luma we put that value into a cookie called X-Magento-Vary which luma will send with each request.
+In this case is the server who computes a cache key on which varnish or fastly can add.
+Luma also stores in cookies the Store and Currency but never the value of customer group.
+
+PWA and Graphql uses a cookieless approach. PWA has to know now about Store and Currency but not about the private components of cache.
+Also each time we change something on private components like in this case with customer-group we have to add something to the VCL in fastly and varnish.
+
+We also missed the fact that the server, since it has these components as variations of cache, should respond with:
+````
+Vary: Store, Content-currency
+````
+
+There is a bug in GraphQL, as it doesn't construct properly the Vary header:
+````
+Vary: Accept-Encoding, Cookie
+````
+
+All components/headers that compose cache key should be included in the Vary.
+
+## Solution
+Graphql would compute the cache key and return a header with the same function as the Luma cookie (`X-Magento-Vary`), except we won't name it that way. The `Vary` header is not meant to have a hash.
+````
+X-Magento-Request-Id: 85a0b196524c60eaeb7c87d1aa4708a3fb20c6a1
+````
+
+PWA would send `X-Magento-Request-Id` back to GraphQL. So it will act like the cookie in Luma. 
+This way we solve the public-private without adding more haders than we have. Just this one time.
+
+This will require a change in VCL but only once. With all the other changes if we change the way cache key is computed, no VCL changes would be required nor in PWA.
+
+VCL/Fastly would process this and turn it into a real cache key processed internally but the edge cache.
+Currently, Fastly has this:
+
+````
+X-Request-Id: chn45aznc4feogj23ssw3y7k
+````
+
+The `X-Magento-Request-Id` will take into account `X-Magento-Request-Id` and respond with a propper Vary header:
+````
+Vary: X-Magento-Request-Id
+````
+
+This is all we need. we don't need to add Store and Content-Currency to Vary anymore, though if we want to be transparent for the public headers we still can.

--- a/design-documents/graph-ql/improved-caching.md
+++ b/design-documents/graph-ql/improved-caching.md
@@ -1,76 +1,82 @@
 ## Current caching
-Like described in [dev docs](https://devdocs.magento.com/guides/v2.4/graphql/caching.html) we create a full query cache which we identify through a unique key
+For GraphQL, we create a full query cache, which has results stored under unique keys as described in the [dev docs](https://devdocs.magento.com/guides/v2.4/graphql/caching.html).
 
-The unique cache key is usually a hash based on several factors which define the type of request, scope etc.
-
-Currently that formula is:
+These unique keys are a combination of several factors which define the scope of a request. Currently, this is the formula used for GraphQL:
 
 ````
-hash([FULL URL + GET PARAMS] + [Store Header Value] + [Content-Currency Header Value])
+[Store Header Value] + [Content-Currency Header Value]
 ````
 
-All three types  of cache (FPC, Varnish and Fastly) now know about those headers and they compute different caches
+All three types of cache (FPC, Varnish, and Fastly) know about these headers and use them to compute their cache keys.
 
 ## The problem
-This strategy only supposes that all components of cache have public values, and knowing their values doesn't pose any security concern.
-There is however what we can call private data that should not really be exposed or at the very least guessed easily if exposed.
+This strategy only allows for all the components of the cache key to have public values, and for a user knowing those values to not pose any security concerns.
+There is, however, what we will call "private data" which should not be exposed, or at the very least it should not be able to be reproduced/guessed easily if it is. 
 
-Take customer-group as an example. At no point in Luma would we expose customer group. Instead we compute the same hash but including customer group and salt it:
+Take Customer Group as an example: At no point in Luma do we expose Customer Group. Instead, we compute a hash using Store and Currency but also including Customer Group and a salt:
 
 ````
-hash([FULL URL + GET PARAMS] + [Store] + [Currency] + [CustomerGroup] + [Salt])
+hash([Store] + [Currency] + [CustomerGroup] + [Salt])
 ````
 
-This works In Luma we put that value into a cookie called X-Magento-Vary which luma will send with each request.
-In this case is the server who computes a cache key on which varnish or fastly can add.
-Luma also stores in cookies the Store and Currency but never the value of customer group.
+Using a salted hash hides the Customer Group from the user but still allows it to be considered as a cache key.
+This works in Luma because we put that value into a cookie called `X-Magento-Vary`, which Luma sends with each request for the VCL code to use to do cache lookups.
+In this case it is the server that computes the cache key for Varnish/Fastly.
+Luma also stores Store and Currency in cookies, but never the value of Customer Group.
 
-PWA and Graphql uses a cookieless approach. PWA has to know now about Store and Currency but not about the private components of cache.
-Also each time we change something on private components like in this case with customer-group we have to add something to the VCL in fastly and varnish.
+PWA and GraphQL, however, use a cookieless approach.
+PWA currently knows about Store and Currency, but not about the private components of the cache key. Because of this, we explicitly bypass the cache for logged-in customers in order to hit Magento and retrieve correct results.
+Also, each time we change what is used for the cache key (such as adding Customer Group), we have to change the VCL in Fastly and Varnish.
 
-We also missed the fact that the server, since it has these components as variations of cache, should respond with:
+Additionally, we missed the fact that the cache node, since it uses these values as components of its own cache key, should respond with this `Vary` header for the browser cache:
 ````
-Vary: Store, Content-currency
+Vary: Store, Content-Currency
 ````
 
-There is a bug in GraphQL, as it doesn't construct properly the Vary header:
+The Fastly VCL code for GraphQL currently has a bug where it returns the same `Vary` header as it does for non-GraphQL requests (which use a cookie to store `X-Magento-Vary`):
 ````
 Vary: Accept-Encoding, Cookie
 ````
 
-All components/headers that compose cache key should be included in the Vary.
+All components/headers that compose the cache key should be included in the `Vary` header read by the browser cache.
 
 ## The Solution
-Graphql would compute the cache key and return a header with the same function as the Luma cookie (`X-Magento-Vary`), except we won't name it that way. The `Vary` header is not meant to have a hash.
+On every request, our GraphQL framework will compute a salted and hashed cache key using the same factors as the Luma `X-Magento-Vary` cookie and return it in a header on the response.
 ````
 X-Magento-Cache-Id: 85a0b196524c60eaeb7c87d1aa4708a3fb20c6a1
 ````
 
-PWA would send `X-Magento-Cache-Id` back to GraphQL. So it will act like the cookie in Luma. 
-This way we solve the public-private without adding more haders than we have. Just this one time.
+PWA will capture this header and send it back on following GraphQL requests, which the cache node will then use as the key.
+This requires a VCL change, but only once; the VCL code will not care about the method used to generate the header, so even if that changes no further updates would be required.
 
-This will require a change in VCL but only once. With all the other changes if we change the way cache key is computed, no VCL changes would be required nor in PWA.
+PWA will continue to capture the header on every response, and when it makes a new request it will send the most recent value it has received.
+This way, if something happens that changes a customer's cache key such as updating their shipping address, PWA will immediately pick it up and use the correct key on the next request.
 
-VCL/Fastly would process this and turn it into a real cache key processed internally but the edge cache.
-Currently, Fastly has this:
+A different value for `X-Magento-Cache-Id` can be sent with than Magento calculates for the request, such as when a user changes their currency (which does not use a mutation).
+When this happens, we cannot cache the response under the `X-Magento-Cache-Id` that was on the request, otherwise incorrect values will be returned for other requests also using the initial value.
+To avoid this issue, the VCL code will compare the `X-Magento-Cache-Id` values on the request and the response and not store the result in the cache if they do not match.
 
+The cache node will respond with a proper `Vary` header for the browser cache to use:
 ````
-X-Request-Id: chn45aznc4feogj23ssw3y7k
+Vary: Store, Content-Currency, Authorization, X-Magento-Cache-Id
 ````
+There is no mutation for changing Store or Currency, so they need to remain in `Vary` for the browser cache to know to use them as keys.
+Likewise, a customer logging out does not use a mutation; instead, PWA just stops sending the `Authorization` header. The browser cache needs to know that this could cause a change in result values, so `Authorization` also needs to be in the `Vary` header. Of note: The VCL code will not consider the full bearer token when doing a cache lookup, just whether it exists on the request at all.
 
-The `X-Magento-Cache-Id` will take into account `X-Magento-Cache-Id` and respond with a propper Vary header:
-````
-Vary: X-Magento-Cache-Id
-````
+Like `X-Magento-Vary`, the hash calculation for the `X-Magento-Cache-Id` header will use an unpredictably random salt. To ensure the salt is consistent between requests, we will store it in the environment configuration.
+However, as this will happen as part of the first GraphQL request without a pre-existing salt, multiple attempts to update the config could occur simultaneously.
+To avoid issues with concurrent write attempts, we will use a lock when writing to the `app/etc/env.php` file while adding the salt.
+Generating this value automatically instead of through an admin interaction will avoid adding a step to the upgrade process and allow us to ensure the salt is sufficiently random.
 
-We don't need to add Store and Content-Currency to Vary anymore, though if we want to be transparent for the public headers we still can.
-For FPC built in cache there would be no changes besides outputing X-Magento-Cache-Id and the proper Vary. We already have the code that computes the cookie hash value.
-This should suffice all explained above except for a major possible security flaw explained below.
+For built-in FPC, there will be no changes other than outputting `X-Magento-Cache-Id` and the proper `Vary`.
+
+This should account for all issues listed above except for a major possible security flaw explained below.
 
 ### The Solution's major flaw
-Since we're caching the whole query and the caching server is hit first, and we don't have yet an auth session service nor a differentiator between auth token and session token
-we wouldn't check if the barer token is valid or not. 
-This works in Luma because they have blocks and in graphql we don't have the equivlent of that. In luma we don't cache blocks marked as private. We use separate ajax to pupulate those after we retrieve the page from cache.
-In graphql we could say that we have as blocks any node Example: product {block { subblock }}. However our use cases here are catalog, prices (which we could populate and not cache).
-In category permissions and shared catalogs, suddenly the whole reponse becomes uncacheable because whole products and categories might be different.
-We couldn't find a viable solution here unless there's some high availability service that checks session token once this will be available part of a full oauth2 protocol in 2.5
+We're caching the whole query, requests hit the caching server first, and we don't (yet) have an auth session service, nor is there a differentiator between auth token and session token. This means we can't currently validate the bearer token before the cache node checks for a hit.
+
+This is not a problem in Luma because it has blocks, and blocks marked as private aren't cached. We use separate ajax to populate those after we retrieve the page from the cache.
+Unfortunately, GraphQL doesn't have any equivalent to Luma's blocks. We could say that a node has a set of blocks (Example: `product {block { subblock }}`), but our current use cases are catalog and prices, which we could populate and not cache.
+For category permissions and shared catalogs, suddenly the whole response stops being cacheable because the products and categories might be different.
+
+We couldn't find a viable solution for this without having some high availability service that checks session token, which will only be possible after having full oauth2 protocol in 2.5.


### PR DESCRIPTION
## Problem
Vary header exposes the wrong data in GraphQL and poses a problem with dish cache in browser.
We also need to add private data part of the cache key like Customer-Group 
<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
Fix the Vary header output in GraphQL
Add `X-Magento-Request-Id` on output as a replacement for X-Magento-Vary cookie and fix VCL 
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
