### PR TITLE
Adjust neg. quote operations to contain sort and status

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -14,7 +14,7 @@ type Query {
 }
 
 type NegotiableQuotesOutput {
-    items: [NegotiableQuote]
+    items: [NegotiableQuote!]!
     page_info: SearchResultPageInfo!
     total_count: Int!
 }
@@ -97,7 +97,6 @@ input DeleteNegotiableQuotesInput {
 }
 
 type DeleteNegotiableQuotesOutput {
-    status: Boolean!
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
@@ -114,7 +113,6 @@ input CloseNegotiableQuotesInput {
 }
 
 type CloseNegotiableQuotesOutput {
-    status: Boolean!
     closed_quotes(
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -9,6 +9,7 @@ type Query {
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,
         currentPage: Int = 1
+        sort: NegotiableQuoteSortInput
     ): NegotiableQuotesOutput @doc(description: "A (optionally filtered) list of negotiable quotes viewable by the logged-in customer")
 }
 
@@ -96,6 +97,7 @@ input DeleteNegotiableQuotesInput {
 }
 
 type DeleteNegotiableQuotesOutput {
+    status: Boolean!
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
@@ -103,6 +105,7 @@ type DeleteNegotiableQuotesOutput {
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,
         currentPage: Int = 1
+        sort: NegotiableQuoteSortInput
     ): NegotiableQuotesOutput @doc(description: "List of negotiable quotes available to customer")
 }
 
@@ -111,12 +114,14 @@ input CloseNegotiableQuotesInput {
 }
 
 type CloseNegotiableQuotesOutput {
-    closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed")
+    status: Boolean!
+    closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed, returns null if none was closed")
     #optionally display all negotiable quotes
     negotiable_quotes(
         filter: NegotiableQuoteFilterInput,
         pageSize: Int = 20,
         currentPage: Int = 1
+        sort: NegotiableQuoteSortInput
     ): NegotiableQuotesOutput @doc(description: "A (optionally filtered) list of negotiable quotes viewable by the logged-in customer")
 }
 
@@ -197,6 +202,17 @@ enum NegotiableQuoteStatus {
 input NegotiableQuoteFilterInput {
     quote_uid: FilterEqualTypeInput @doc(description: "Filter by quote UID(s)")
     name: FilterMatchTypeInput @doc(description: "Filter by negotiable quote name")
+}
+
+input NegotiableQuoteSortInput {
+    name: SortEnum @doc(description: "Sort by negotiable quote name")
+    status: SortEnum
+    created_at: SortEnum
+    updated_at: SortEnum
+    # Some other nice to have fields are, which will not be part of MVP
+    is_virtual: SortEnum
+    grand_total: SortEnum
+    total_quantity: SortEnum
 }
 
 type NegotiableQuoteHistoryEntry {

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -17,6 +17,7 @@ type NegotiableQuotesOutput {
     items: [NegotiableQuote!]!
     page_info: SearchResultPageInfo!
     total_count: Int!
+    sort_fields: SortFields
 }
 
 # Coverage missing:

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -14,7 +14,7 @@ type Query {
 }
 
 type NegotiableQuotesOutput {
-    items: [NegotiableQuote]!
+    items: [NegotiableQuote]
     page_info: SearchResultPageInfo!
     total_count: Int!
 }
@@ -115,7 +115,12 @@ input CloseNegotiableQuotesInput {
 
 type CloseNegotiableQuotesOutput {
     status: Boolean!
-    closed_quotes: [NegotiableQuote!] @doc(description: "Quotes that were just closed, returns null if none was closed")
+    closed_quotes(
+        filter: NegotiableQuoteFilterInput,
+        pageSize: Int = 20,
+        currentPage: Int = 1
+        sort: NegotiableQuoteSortInput
+    ): NegotiableQuotesOutput @doc(description: "Quotes that were just closed")
     #optionally display all negotiable quotes
     negotiable_quotes(
         filter: NegotiableQuoteFilterInput,


### PR DESCRIPTION
## Problem

Mutations in schema is not align with statuses on operations that might have partial or total success, which is an overall effort. 
We also can't sort the quotes returned. 
<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
To align mutations schema with operations that might have partial or total success, we need to add statuses.
Also we can add sorting on quotes solving the sorting problems

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
