### PR TITLE
PWA-1631: Add the Negotiable Quote admin configuration information to the storeConfig query

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -327,3 +327,7 @@ type NegotiableQuoteUser @doc(description: "A limited view of a Buyer or Seller 
     firstname: String!
     lastname: String!
 }
+
+type StoreConfig {
+    is_negotiable_quote_active: Boolean @doc(description: "Indicates if negotiable quote functionality is enabled.")
+}


### PR DESCRIPTION
## Problem
The current storeConfig query does not contain information about the Negotiable Quote configuration.
<!-- In a few words, describe the problem being solved with the proposal. -->


## Solution
Extend the storeConfig query from within the NegotiableQuoteGraphQl schema to include this.
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers
@cpartica 
@prabhuram93 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
