### PR TITLE
Add original_total_price to prices field on negotiable quotes

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -173,7 +173,7 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
-    prices: CartPrices
+    prices: NegotiableQuoteCartPrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")
     updated_at: String @doc(description: "Timestamp indicating when the negotiable quote was updated.")
@@ -207,7 +207,7 @@ type NegotiableQuoteHistoryEntry {
     changes: NegotiableQuoteHistoryChanges
 }
 
-type CartPrices {
+type NegotiableQuoteCartPrices {
     grand_total: Money
     subtotal_including_tax: Money
     subtotal_excluding_tax: Money

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -208,13 +208,13 @@ type NegotiableQuoteHistoryEntry {
 }
 
 type CartPrices {
-    original_total_price: Money
+    initial_total_price: Money
 }
 
 type CartItemPrices {
-    original_price: Money
-    original_row_total: Money
-    original_row_total_including_tax: Money
+    initial_price: Money
+    initial_row_total: Money
+    initial_row_total_including_tax: Money
 }
 
 # Note: Most of these HistoryChange types were built based on looking through UI code in Luma, because we don't have existing API

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -207,6 +207,17 @@ type NegotiableQuoteHistoryEntry {
     changes: NegotiableQuoteHistoryChanges
 }
 
+type CartPrices {
+    grand_total: Money
+    subtotal_including_tax: Money
+    subtotal_excluding_tax: Money
+    discount: CartDiscount @deprecated(reason: "Use discounts instead ")
+    subtotal_with_discount_excluding_tax: Money
+    applied_taxes: [CartTaxItem]
+    discounts: [Discount] @doc(description:"An array of applied discounts")
+    original_total_price: Money
+}
+
 # Note: Most of these HistoryChange types were built based on looking through UI code in Luma, because we don't have existing API
 #       support for the Negotiable Quote history log feature. If we find these types aren't ideal during implementation,
 #       let's iterate rather than stay glued to them.

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -173,7 +173,7 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
-    prices: NegotiableQuoteCartPrices
+    prices: CartPrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")
     updated_at: String @doc(description: "Timestamp indicating when the negotiable quote was updated.")
@@ -207,15 +207,13 @@ type NegotiableQuoteHistoryEntry {
     changes: NegotiableQuoteHistoryChanges
 }
 
-type NegotiableQuoteCartPrices {
-    grand_total: Money
-    subtotal_including_tax: Money
-    subtotal_excluding_tax: Money
-    discount: CartDiscount @deprecated(reason: "Use discounts instead ")
-    subtotal_with_discount_excluding_tax: Money
-    applied_taxes: [CartTaxItem]
-    discounts: [Discount] @doc(description:"An array of applied discounts")
+type CartPrices {
     original_total_price: Money
+}
+
+type CartItemPrices {
+    original_price: Money
+    original_row_total: Money
 }
 
 # Note: Most of these HistoryChange types were built based on looking through UI code in Luma, because we don't have existing API

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -214,6 +214,7 @@ type CartPrices {
 type CartItemPrices {
     original_price: Money
     original_row_total: Money
+    original_row_total_including_tax: Money
 }
 
 # Note: Most of these HistoryChange types were built based on looking through UI code in Luma, because we don't have existing API


### PR DESCRIPTION
## Problem

We want to report the non-negotiated price of a negotiable quote
Internal ticket: [PWA-1663](https://jira.corp.magento.com/browse/PWA-1663)

## Solution

* Add a field to the CartPrices type originally in QuoteGraphQL with the original_total_price value from the negotiable_quote table
* Add a field to the CartItemPrices type originally in QuoteGraphQL with the original_price value from the negotiable_quote_item table
* Add original_row_total and original_row_total_including_tax fields to the CartItemPrices type originally in QuoteGraphQL with calculated values based on the original_price and original_tax_amount values from the negotiable_quote_item table multiplied by item quantity

## Requested Reviewers

@cpartica @prabhuram93 
