### PR TITLE
Remove addNegotiableQuoteComment mutation

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -29,11 +29,6 @@ type Mutation {
         input: RequestNegotiableQuoteInput!
     ): RequestNegotiableQuoteOutput @doc(description: "Request a new negotiable quote for a buyer")
 
-    # Covers "Add your Comment" section of https://docs.magento.com/user-guide/customers/account-dashboard-quotes-negotiate.html#shipping-information
-    addNegotiableQuoteComment(
-        input: AddNegotiableQuoteCommentInput!
-    ): AddNegotiableQuoteCommentOutput @doc(description: "Append a new comment from the buyer to a negotiable quote")
-
     # https://docs.magento.com/user-guide/customers/account-dashboard-quotes-negotiate.html#change-the-quantity
     updateNegotiableQuoteQuantities(
         input: UpdateNegotiableQuoteQuantitiesInput!
@@ -167,11 +162,6 @@ input RequestNegotiableQuoteInput {
 input NegotiableQuoteCommentInput {
     comment: String!
     # files (attachments) to be added at a later date when file upload design has been finalized
-}
-
-input AddNegotiableQuoteCommentInput {
-    quote_uid: ID!
-    comment: NegotiableQuoteCommentInput!
 }
 
 type NegotiableQuoteComment {
@@ -351,11 +341,6 @@ type RequestNegotiableQuoteOutput {
 }
 
 type RemoveNegotiableQuoteItemsOutput {
-    quote: NegotiableQuote
-}
-
-type AddNegotiableQuoteCommentOutput {
-    comment: NegotiableQuoteComment @doc(description: "The newly added comment")
     quote: NegotiableQuote
 }
 

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -83,7 +83,7 @@ input SetNegotiableQuoteShippingAddressInput {
 
 input SendNegotiableQuoteForReviewInput {
     quote_uid: ID! @doc(description: "ID obtained from NegotiableQuote type")
-    comment: NegotiableQuoteCommentInput!
+    comment: NegotiableQuoteCommentInput
 }
 
 type SendNegotiableQuoteForReviewOutput {


### PR DESCRIPTION
## Problem

A user should not be able to add a comment to a Negotiable Quote without submitting it for review.

## Solution

Removed the mutation from the schema.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
