### PR TITLE
Enforce restriction on multiple sorting through Negotiable Quote schema

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -17,6 +17,7 @@ type NegotiableQuotesOutput {
     items: [NegotiableQuote!]!
     page_info: SearchResultPageInfo!
     total_count: Int!
+    sort_fields: SortFields
 }
 
 # Coverage missing:

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -218,7 +218,6 @@ input NegotiableQuoteSortInput {
 
 enum NegotiableQuoteSortableField {
     QUOTE_NAME
-    STATUS
     CREATED_AT
     UPDATED_AT
 }

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -17,7 +17,6 @@ type NegotiableQuotesOutput {
     items: [NegotiableQuote!]!
     page_info: SearchResultPageInfo!
     total_count: Int!
-    sort_fields: SortFields
 }
 
 # Coverage missing:
@@ -212,14 +211,15 @@ input NegotiableQuoteFilterInput {
 }
 
 input NegotiableQuoteSortInput {
-    name: SortEnum @doc(description: "Sort by negotiable quote name")
-    status: SortEnum
-    created_at: SortEnum
-    updated_at: SortEnum
-    # Some other nice to have fields are, which will not be part of MVP
-    is_virtual: SortEnum
-    grand_total: SortEnum
-    total_quantity: SortEnum
+    sort_field: NegotiableQuoteSortableField!
+    sort_direction: SortEnum!
+}
+
+enum NegotiableQuoteSortableField {
+    QUOTE_NAME
+    STATUS
+    CREATED_AT
+    UPDATED_AT
 }
 
 type NegotiableQuoteHistoryEntry {


### PR DESCRIPTION
## Problem

Negotiable Quote GQL implementation restricts sorting via multiple fields. This PR enables schema to enforce that restriction.

## Solution

Added changes in teh schema

## Requested Reviewers

@cpartica  @pdohogne-magento 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
