### PR TITLE
Add Storefront properties for Product Attributes

### DIFF
--- a/design-documents/graph-ql/coverage/eav/EavGraphQl.graphqls
+++ b/design-documents/graph-ql/coverage/eav/EavGraphQl.graphqls
@@ -1,0 +1,42 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+type Query {
+    customAttributeMetadata(attributes: [AttributeInput!]!): CustomAttributeMetadata @resolver(class: "Magento\\EavGraphQl\\Model\\Resolver\\CustomAttributeMetadata") @doc(description: "The customAttributeMetadata query returns the attribute type, given an attribute code and entity type") @cache(cacheable: false)
+}
+
+type CustomAttributeMetadata @doc(description: "CustomAttributeMetadata defines an array of attribute_codes and entity_types") {
+    items: [Attribute] @doc(description: "An array of attributes")
+}
+
+type Attribute @doc(description: "Attribute contains the attribute_type of the specified attribute_code and entity_type") {
+    attribute_code: String @doc(description: "The unique identifier for an attribute code. This value should be in lowercase letters without spaces.")
+    entity_type: String @doc(description: "The type of entity that defines the attribute")
+    attribute_type: String @doc(description: "The data type of the attribute")
+    input_type: String @doc(description: "The frontend input type of the attribute")
+    attribute_options: [AttributeOption] @resolver(class: "Magento\\EavGraphQl\\Model\\Resolver\\AttributeOptions") @doc(description: "Attribute options list.")
+    storefront_properties: StorefrontProperties
+}
+
+type StorefrontProperties {
+   used_in_product_listing: Boolean
+   position: Int
+   visible_on_catalog_storefront: Boolean
+   use_in_layered_navigation: UseInLayeredNavigationOptions
+}
+
+enum UseInLayeredNavigationOptions {
+  NO
+  FILTERABLE_WTH_RESULTS
+  FILTERABLE_NO_RESULT
+}
+
+type AttributeOption @doc(description: "Attribute option.") {
+    label: String @doc(description: "Attribute option label.")
+    value: String @doc(description: "Attribute option value.")
+}
+
+input AttributeInput @doc(description: "AttributeInput specifies the attribute_code and entity_type to search") {
+    attribute_code: String @doc(description: "The unique identifier for an attribute code. This value should be in lowercase letters without spaces.")
+    entity_type: String @doc(description: "The type of entity that defines the attribute")
+}


### PR DESCRIPTION
## Problem

[PWA-1665](https://jira.corp.magento.com/browse/PWA-1665)
Need to control the use of product attributes on PWA Venia Storefront

## Solution

Added a field storefront_properties in the customAttributeMetadata query to expose admin configuration on product attributes related to storefront.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
