### PR TITLE
Added additional options to updateCartItems mutation

### DIFF
--- a/design-documents/graph-ql/coverage/quote.graphqls
+++ b/design-documents/graph-ql/coverage/quote.graphqls
@@ -89,6 +89,8 @@ input CartItemUpdateInput {
     cart_item_interface_uid: ID @doc(description: "Required field. Unique Identifier from objects implementing `CartItemInterface`")
     quantity: Float
     customizable_options: [CustomizableOptionInput!]
+    selected_options: [ID!]
+    entered_options: [EnteredOptionInput!]
 }
 
 input RemoveItemFromCartInput {


### PR DESCRIPTION
## Problem
[PWA-1827](https://jira.corp.magento.com/browse/PWA-1827): Cannot update Bundle Product selected options quantity in cart 
<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
We have selected_options & entered_options in the addProductsToCart mutation, but not in the updateCartItems mutation. The updateCartItems mutation should be updated to include these fields and function similarly to the addProductsToCart mutation.
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers
@cpartica 
<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
