### PR TITLE
MC-42795: GraphQl products query layered navigation filters return incorrect child categories list

### DIFF
--- a/design-documents/graph-ql/coverage/catalog.graphqls
+++ b/design-documents/graph-ql/coverage/catalog.graphqls
@@ -316,8 +316,12 @@ type Products @doc(description: "The Products object is the top-level object ret
     page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query.")
     total_count: Int @doc(description: "The number of products that are marked as visible. By default, in complex products, parent products are visible, but their child products are not.")
     filters: [LayerFilter] @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\LayerFilters") @doc(description: "Layered navigation filters array.") @deprecated(reason: "Use aggregations instead")
-    aggregations: [Aggregation] @doc(description: "Layered navigation aggregations.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Aggregations")
+    aggregations (filter: AggregationsFilterInput): [Aggregation] @doc(description: "Layered navigation aggregations.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Aggregations")
     sort_fields: SortFields @doc(description: "An object that includes the default sort field and all available sort fields.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\SortFields")
+}
+
+input AggregationsFilterInput {
+    includeSubcategoriesOnly: Boolean = false @doc(description: "Flag to include only subcategories of requested category.")
 }
 
 type CategoryProducts @doc(description: "The category products object returned in the Category query.") {

--- a/design-documents/graph-ql/coverage/catalog.graphqls
+++ b/design-documents/graph-ql/coverage/catalog.graphqls
@@ -316,7 +316,7 @@ type Products @doc(description: "The Products object is the top-level object ret
     page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query.")
     total_count: Int @doc(description: "The number of products that are marked as visible. By default, in complex products, parent products are visible, but their child products are not.")
     filters: [LayerFilter] @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\LayerFilters") @doc(description: "Layered navigation filters array.") @deprecated(reason: "Use aggregations instead")
-    aggregations (filter: AggregationsFilterInput): [Aggregation] @doc(description: "Layered navigation aggregations.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Aggregations")
+    aggregations (filter: AggregationsFilterInput): [Aggregation] @doc(description: "Layered navigation aggregations with filters.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Aggregations")
     sort_fields: SortFields @doc(description: "An object that includes the default sort field and all available sort fields.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\SortFields")
 }
 


### PR DESCRIPTION
## Scope
### Bug
* [MC-42795](https://jira.corp.magento.com/browse/MC-42795) GraphQl products query layered navigation filters return incorrect child categories list
### Related Pull Requests
<!-- related pull request placeholder -->
### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green