### PR TITLE
MC-42795: GraphQl products query layered navigation filters return incorrect child categories list

### DIFF
--- a/design-documents/graph-ql/coverage/catalog.graphqls
+++ b/design-documents/graph-ql/coverage/catalog.graphqls
@@ -320,12 +320,12 @@ type Products @doc(description: "The Products object is the top-level object ret
     sort_fields: SortFields @doc(description: "An object that includes the default sort field and all available sort fields.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\SortFields")
 }
 
-input AggregationsFilterInput @doc(description: "Filter aggregations in layered navigation.") {
+input AggregationsFilterInput @doc(description: "An input object that specifies the filters used in product aggregations.") {
     category: AggregationsCategoryFilterInput @doc(description: "Filter category aggregations in layered navigation.")
 }
 
 input AggregationsCategoryFilterInput @doc(description: "Filter category aggregations in layered navigation."){
-    includeDirectChildrenOnly: Boolean = false @doc(description: "Flag to include only direct subcategories of requested category.")
+    includeDirectChildrenOnly: Boolean = false @doc(description: "Indicates whether to include only direct subcategories or all children categories at all levels.")
 }
 
 type CategoryProducts @doc(description: "The category products object returned in the Category query.") {

--- a/design-documents/graph-ql/coverage/catalog.graphqls
+++ b/design-documents/graph-ql/coverage/catalog.graphqls
@@ -320,8 +320,12 @@ type Products @doc(description: "The Products object is the top-level object ret
     sort_fields: SortFields @doc(description: "An object that includes the default sort field and all available sort fields.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\SortFields")
 }
 
-input AggregationsFilterInput {
-    includeSubcategoriesOnly: Boolean = false @doc(description: "Flag to include only subcategories of requested category.")
+input AggregationsFilterInput @doc(description: "Filter aggregations in layered navigation.") {
+    category: AggregationsCategoryFilterInput @doc(description: "Filter category aggregations in layered navigation.")
+}
+
+input AggregationsCategoryFilterInput @doc(description: "Filter category aggregations in layered navigation."){
+    includeDirectChildrenOnly: Boolean = false @doc(description: "Flag to include only direct subcategories of requested category.")
 }
 
 type CategoryProducts @doc(description: "The category products object returned in the Category query.") {


### PR DESCRIPTION
## Scope
### Bug
* [MC-42795](https://jira.corp.magento.com/browse/MC-42795) GraphQl products query layered navigation filters return incorrect child categories list
### Related Pull Requests
<!-- related pull request placeholder -->
### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green