### PR TITLE
PWA-2114: Create mutation to set payment method on negotiable quote

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -54,7 +54,7 @@ type Mutation {
     setNegotiableQuoteShippingAddress(
         input: SetNegotiableQuoteShippingAddressInput!
     ): SetNegotiableQuoteShippingAddressOutput @doc(description: "Assign one of buyers' existing addresses to a negotiable quote")
-    
+
     sendNegotiableQuoteForReview(
         input: SendNegotiableQuoteForReviewInput!
     ) : SendNegotiableQuoteForReviewOutput @doc(description: "Send the negotiable quote for review to the seller")
@@ -63,6 +63,10 @@ type Mutation {
     # addNegotiableQuoteFiles(
     #     input: AddNegotiableQuoteFilesInput!
     # ): AddNegotiableQuoteFilesInput
+
+    setNegotiableQuotePaymentMethod(
+        input: SetNegotiableQuotePaymentMethodInput!
+    ): SetNegotiableQuotePaymentMethodOutput @doc(description: "Set the payment method on the negotiable quote")
 }
 
 type AddNegotiableQuoteItemsOutput {
@@ -315,7 +319,7 @@ type NegotiableQuoteHistoryProductsRemovedChange {
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L148-L169
 type NegotiableQuoteHistoryProductsAddedChange {
-    # TODO: List of products added and their respective options.   
+    # TODO: List of products added and their respective options.
 }
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L172-L197
@@ -358,4 +362,13 @@ type NegotiableQuoteUser @doc(description: "A limited view of a Buyer or Seller 
 
 type StoreConfig {
     is_negotiable_quote_active: Boolean @doc(description: "Indicates if negotiable quote functionality is enabled.")
+}
+
+input SetNegotiableQuotePaymentMethodInput {
+    quote_uid: ID! @doc(description: "ID obtained from NegotiableQuote object")
+    code: String! @doc(description:"Payment method code")
+}
+
+type SetNegotiableQuotePaymentMethodOutput {
+    quote: NegotiableQuote
 }

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -189,8 +189,8 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
-    available_payment_methods: [AvailablePaymentMethod]
-    selected_payment_method: SelectedPaymentMethod
+    available_payment_methods: [NegotiableQuoteAvailablePaymentMethod]
+    selected_payment_method: NegotiableQuoteSelectedPaymentMethod
     prices: NegotiableQuotePrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")
@@ -378,4 +378,15 @@ input NegotiableQuotePaymentMethodInput {
 
 type SetNegotiableQuotePaymentMethodOutput {
     quote: NegotiableQuote
+}
+
+type NegotiableQuoteAvailablePaymentMethod {
+    code: String! @doc(description: "The payment method code")
+    title: String! @doc(description: "The payment method title.")
+}
+
+type NegotiableQuoteSelectedPaymentMethod {
+    code: String! @doc(description: "The payment method code")
+    title: String! @doc(description: "The payment method title.")
+    purchase_order_number: String @doc(description: "The purchase order number.")
 }

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -368,7 +368,12 @@ type StoreConfig {
 
 input SetNegotiableQuotePaymentMethodInput {
     quote_uid: ID! @doc(description: "ID obtained from NegotiableQuote object")
+    payment_method: NegotiableQuotePaymentMethodInput!
+}
+
+input NegotiableQuotePaymentMethodInput {
     code: String! @doc(description:"Payment method code")
+    purchase_order_number: String @doc(description:"Purchase order number")
 }
 
 type SetNegotiableQuotePaymentMethodOutput {

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -189,6 +189,8 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
+    available_payment_methods: [AvailablePaymentMethod]
+    selected_payment_method: SelectedPaymentMethod
     prices: NegotiableQuotePrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
We cannot currently support end-to-end checkout of negotiable quotes in GraphQL because several mutations are missing, including one to set the payment method on the negotiable quote. (Other missing mutations will be addressed separately.)

## Solution

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->
Add the setNegotiableQuotePaymentMethod mutation to the NegotiableQuoteGraphQl schema and return the full negotiable quote as the output.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
