### PR TITLE
PWA-2113: [GraphQL] Create mutation to set billing address on negotiable quote

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -94,7 +94,7 @@ input NegotiableQuoteBillingAddressInput {
     customer_address_id: Int
     address: NegotiableQuoteAddressInput
     use_for_shipping: Boolean @doc(description: "Indicates whether to additionally set the shipping address based on the provided billing address")
-    same_as_shipping: Boolean @doc(description: "Indicates whether to set the billing address based on the existing shipping address on the cart")
+    same_as_shipping: Boolean @doc(description: "Indicates whether to set the billing address based on the existing shipping address on the negotiable quote")
 }
 
 input NegotiableQuoteAddressInput {
@@ -215,12 +215,37 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
-    billing_address: BillingCartAddress
+    billing_address: NegotiableQuoteAddress
     prices: NegotiableQuotePrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")
     updated_at: String @doc(description: "Timestamp indicating when the negotiable quote was updated.")
     status: NegotiableQuoteStatus!
+}
+
+type NegotiableQuoteAddress implements NegotiableQuoteAddressInterface {
+}
+
+interface NegotiableQuoteAddressInterface {
+    firstname: String
+    lastname: String
+    company: String
+    street: [String]
+    city: String
+    region: NegotiableQuoteAddressRegion
+    postcode: String
+    country: NegotiableQuoteAddressCountry
+    telephone: String
+}
+
+type NegotiableQuoteAddressRegion {
+    code: String
+    label: String
+}
+
+type NegotiableQuoteAddressCountry {
+    code: String
+    label: String
 }
 
 # Implementation Note: Using the values from the "Buyer Status" column of the state mapping table in devdocs.

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -215,7 +215,7 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
-    billing_address: NegotiableQuoteAddress
+    billing_address: NegotiableQuoteBillingAddress
     prices: NegotiableQuotePrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")
@@ -223,7 +223,7 @@ type NegotiableQuote {
     status: NegotiableQuoteStatus!
 }
 
-type NegotiableQuoteAddress implements NegotiableQuoteAddressInterface {
+type NegotiableQuoteBillingAddress implements NegotiableQuoteAddressInterface {
 }
 
 interface NegotiableQuoteAddressInterface {

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -54,10 +54,14 @@ type Mutation {
     setNegotiableQuoteShippingAddress(
         input: SetNegotiableQuoteShippingAddressInput!
     ): SetNegotiableQuoteShippingAddressOutput @doc(description: "Assign one of buyers' existing addresses to a negotiable quote")
-    
+
     sendNegotiableQuoteForReview(
         input: SendNegotiableQuoteForReviewInput!
     ) : SendNegotiableQuoteForReviewOutput @doc(description: "Send the negotiable quote for review to the seller")
+
+    setNegotiableQuoteBillingAddress(
+        input: SetNegotiableQuoteBillingAddressInput!
+    ): SetNegotiableQuoteBillingAddressOutput @doc(description: "Assign one of buyers' existing addresses to a negotiable quote")
 
     # Pending decision on design of file upload (design doc still pending decisions)
     # addNegotiableQuoteFiles(
@@ -79,6 +83,14 @@ input SetNegotiableQuoteShippingAddressInput {
     customer_address_id: Int! @doc(
         description: "ID obtained from the CustomerAddress type. A new address can be added using Mutation.createCustomerAddress"
     )
+}
+
+input SetNegotiableQuoteBillingAddressInput {
+    quote_uid: ID! @doc(description: "ID obtained from NegotiableQuote type")
+    customer_address_id: Int @doc(
+        description: "ID obtained from the CustomerAddress type. A new address can be added using Mutation.createCustomerAddress"
+    )
+    new_customer_address: CustomerAddressInput @doc(description: "New address to be added")
 }
 
 input SendNegotiableQuoteForReviewInput {
@@ -315,7 +327,7 @@ type NegotiableQuoteHistoryProductsRemovedChange {
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L148-L169
 type NegotiableQuoteHistoryProductsAddedChange {
-    # TODO: List of products added and their respective options.   
+    # TODO: List of products added and their respective options.
 }
 
 # Usage in Luma: https://github.com/magento/magento2b2b/blob/0e791b5f7cd604ee6ee40b7225807c01b7f70cf2/app/code/Magento/NegotiableQuote/view/base/templates/quote/history.phtml#L172-L197
@@ -358,4 +370,8 @@ type NegotiableQuoteUser @doc(description: "A limited view of a Buyer or Seller 
 
 type StoreConfig {
     is_negotiable_quote_active: Boolean @doc(description: "Indicates if negotiable quote functionality is enabled.")
+}
+
+type SetNegotiableQuoteBillingAddressOutput {
+    quote: NegotiableQuote
 }

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -61,7 +61,7 @@ type Mutation {
 
     setNegotiableQuoteBillingAddress(
         input: SetNegotiableQuoteBillingAddressInput!
-    ): SetNegotiableQuoteBillingAddressOutput @doc(description: "Assign one of buyers' existing addresses to a negotiable quote")
+    ): SetNegotiableQuoteBillingAddressOutput @doc(description: "Assign a billing address to a negotiable quote")
 
     # Pending decision on design of file upload (design doc still pending decisions)
     # addNegotiableQuoteFiles(
@@ -87,7 +87,28 @@ input SetNegotiableQuoteShippingAddressInput {
 
 input SetNegotiableQuoteBillingAddressInput {
     quote_uid: ID! @doc(description: "ID obtained from NegotiableQuote type")
-    billing_address: BillingAddressInput!
+    billing_address: NegotiableQuoteBillingAddressInput!
+}
+
+input NegotiableQuoteBillingAddressInput {
+    customer_address_id: Int
+    address: NegotiableQuoteAddressInput
+    use_for_shipping: Boolean @doc(description: "Indicates whether to additionally set the shipping address based on the provided billing address")
+    same_as_shipping: Boolean @doc(description: "Indicates whether to set the billing address based on the existing shipping address on the cart")
+}
+
+input NegotiableQuoteAddressInput {
+    firstname: String!
+    lastname: String!
+    company: String
+    street: [String!]!
+    city: String!
+    region: String
+    region_id: Int
+    postcode: String
+    country_code: String!
+    telephone: String
+    save_in_address_book: Boolean
 }
 
 input SendNegotiableQuoteForReviewInput {

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -227,25 +227,26 @@ type NegotiableQuoteBillingAddress implements NegotiableQuoteAddressInterface {
 }
 
 interface NegotiableQuoteAddressInterface {
-    firstname: String
-    lastname: String
+    firstname: String!
+    lastname: String!
     company: String
-    street: [String]
-    city: String
+    street: [String!]!
+    city: String!
     region: NegotiableQuoteAddressRegion
     postcode: String
-    country: NegotiableQuoteAddressCountry
+    country: NegotiableQuoteAddressCountry!
     telephone: String
 }
 
 type NegotiableQuoteAddressRegion {
     code: String
     label: String
+    region_id: Int
 }
 
 type NegotiableQuoteAddressCountry {
-    code: String
-    label: String
+    code: String!
+    label: String!
 }
 
 # Implementation Note: Using the values from the "Buyer Status" column of the state mapping table in devdocs.

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -87,10 +87,7 @@ input SetNegotiableQuoteShippingAddressInput {
 
 input SetNegotiableQuoteBillingAddressInput {
     quote_uid: ID! @doc(description: "ID obtained from NegotiableQuote type")
-    customer_address_id: Int @doc(
-        description: "ID obtained from the CustomerAddress type. A new address can be added using Mutation.createCustomerAddress"
-    )
-    new_customer_address: CustomerAddressInput @doc(description: "New address to be added")
+    billing_address: BillingAddressInput!
 }
 
 input SendNegotiableQuoteForReviewInput {
@@ -197,6 +194,7 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
+    billing_address: BillingCartAddress
     prices: NegotiableQuotePrices
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")

--- a/design-documents/graph-ql/coverage/cart/CartAddressOperations.graphqls
+++ b/design-documents/graph-ql/coverage/cart/CartAddressOperations.graphqls
@@ -22,7 +22,8 @@ input SetBillingAddressOnCartInput {
 input BillingAddressInput {
     customer_address_id: Int
     address: CartAddressInput
-    use_for_shipping: Boolean
+    use_for_shipping: Boolean @doc(description: "Indicates whether to additionally set the shipping address based on the provided billing address")
+    same_as_shipping: Boolean @doc(description: "Indicates whether to set the billing address based on the existing shipping address on the cart")
 }
 
 input SetShippingAddressesOnCartInput {


### PR DESCRIPTION
## Problem
<!-- In a few words, describe the problem being solved with the proposal. -->
We cannot currently support end-to-end checkout of negotiable quotes in GraphQL because several mutations are missing, including one to set the billing address on the negotiable quote. (Other missing mutations will be addressed separately.)

## Solution
<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->
Add the setNegotiableQuoteBillingAddress mutation to the NegotiableQuoteGraphQl schema and return the full negotiable quote as the output.


## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
