### PR TITLE
[GraphQL] Added mutation to set shipping methods on negotiable quote

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -49,28 +49,32 @@ type Mutation {
         input: DeleteNegotiableQuotesInput!
     ): DeleteNegotiableQuotesOutput @doc(description: "Delete a negotiable quote, removing it from the display in the storefront")
 
+    sendNegotiableQuoteForReview(
+        input: SendNegotiableQuoteForReviewInput!
+    ) : SendNegotiableQuoteForReviewOutput @doc(description: "Send the negotiable quote for review to the seller")
+
     # Covers "Select Existing Address" in https://docs.magento.com/user-guide/customers/account-dashboard-quotes-negotiate.html#shipping-information
     # "New Address" flow is covered by Mutation.createCustomerAddress
     setNegotiableQuoteShippingAddress(
         input: SetNegotiableQuoteShippingAddressInput!
     ): SetNegotiableQuoteShippingAddressOutput @doc(description: "Assign one of buyers' existing addresses to a negotiable quote")
 
-    sendNegotiableQuoteForReview(
-        input: SendNegotiableQuoteForReviewInput!
-    ) : SendNegotiableQuoteForReviewOutput @doc(description: "Send the negotiable quote for review to the seller")
-
     setNegotiableQuoteBillingAddress(
         input: SetNegotiableQuoteBillingAddressInput!
     ): SetNegotiableQuoteBillingAddressOutput @doc(description: "Assign a billing address to a negotiable quote")
+
+    setNegotiableQuoteShippingMethods(
+        input: SetNegotiableQuoteShippingMethodsInput!
+    ): SetNegotiableQuoteShippingMethodsOutput @doc(description: "Assign the shipping methods on the negotiable quote")
+
+    setNegotiableQuotePaymentMethod(
+        input: SetNegotiableQuotePaymentMethodInput!
+    ): SetNegotiableQuotePaymentMethodOutput @doc(description: "Set the payment method on the negotiable quote")
 
     # Pending decision on design of file upload (design doc still pending decisions)
     # addNegotiableQuoteFiles(
     #     input: AddNegotiableQuoteFilesInput!
     # ): AddNegotiableQuoteFilesInput
-
-    setNegotiableQuotePaymentMethod(
-        input: SetNegotiableQuotePaymentMethodInput!
-    ): SetNegotiableQuotePaymentMethodOutput @doc(description: "Set the payment method on the negotiable quote")
 }
 
 type AddNegotiableQuoteItemsOutput {
@@ -144,6 +148,15 @@ input NegotiableQuoteAddressInput {
     country_code: String!
     telephone: String
     save_in_address_book: Boolean
+}
+
+input SetNegotiableQuoteShippingMethodsInput {
+    quote_uid: ID!
+    shipping_methods: [ShippingMethodInput!]!
+}
+
+type SetNegotiableQuoteShippingMethodsOutput {
+    quote: NegotiableQuote
 }
 
 input SendNegotiableQuoteForReviewInput {
@@ -262,6 +275,8 @@ type NegotiableQuote {
 }
 
 type NegotiableQuoteShippingAddress implements NegotiableQuoteAddressInterface {
+    available_shipping_methods: [AvailableShippingMethod]
+    selected_shipping_method: SelectedShippingMethod
 }
 
 type NegotiableQuoteBillingAddress implements NegotiableQuoteAddressInterface {


### PR DESCRIPTION
## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
In order to checkout with a negotiable quote, we need a way to set the shipping methods on it first.

## Solution

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->
Add a mutation to set the shipping methods on a negotiable quote.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
