### PR TITLE
[PWA-2062] reCAPTCHA for PWA

### DIFF
--- a/design-documents/graph-ql/coverage/re-captcha.graphqls
+++ b/design-documents/graph-ql/coverage/re-captcha.graphqls
@@ -1,0 +1,31 @@
+enum ReCaptchaVersion {
+  V3
+}
+
+enum ReCaptchaForms {
+  APPLY_GIFT_CARD
+  APPLY_COUPON
+  CHANGE_PASSWORD
+  CHECKOUT
+  LOGIN
+  CREATE_CUSTOMER
+  EDIT_CUSTOMER
+  NEWSLETTER
+}
+
+type ReCaptchaConfiguration {
+  type: ReCaptchaVersion!
+  website_key: String!
+  minimum_score: Float!
+  badge_position: String!
+  language_code: String
+  failure_message: String!
+  forms: [ReCaptchaForms!]!
+}
+
+# Google reCAPTCHA config - will return null if v3 invisible is not configured
+# for at least one Storefront form.
+type StoreConfig {
+  recaptcha: ReCaptchaConfiguration
+    @doc(description: "Google reCAPTCHA Configuration")
+}

--- a/design-documents/graph-ql/coverage/re-captcha.graphqls
+++ b/design-documents/graph-ql/coverage/re-captcha.graphqls
@@ -1,31 +1,44 @@
-enum ReCaptchaVersion {
-  V3
-}
-
-enum ReCaptchaForms {
-  APPLY_GIFT_CARD
-  APPLY_COUPON
-  CHANGE_PASSWORD
-  CHECKOUT
-  LOGIN
-  CREATE_CUSTOMER
-  EDIT_CUSTOMER
+enum ReCaptchaFormEnum {
+  PLACE_ORDER
+  CONTACT
+  CUSTOMER_LOGIN
+  CUSTOMER_FORGOT_PASSWORD
+  CUSTOMER_CREATE
+  CUSTOMER_EDIT
   NEWSLETTER
+  PRODUCT_REVIEW
+  SENDFRIEND
+  BRAINTREE
 }
 
-type ReCaptchaConfiguration {
-  type: ReCaptchaVersion!
+type ReCaptchaConfigurationV3 {
   website_key: String!
+    @doc(
+      description: "The website key that is created when you register your Google reCAPTCHA account"
+    )
   minimum_score: Float!
+    @doc(
+      description: "The minimum score that identifies a user interaction as a potential risk"
+    )
   badge_position: String!
+    @doc(
+      description: "The position of the invisible reCAPTCHA badge on each page"
+    )
   language_code: String
+    @doc(
+      description: "A two-character code that specifies the language that is used for Google reCAPTCHA text and messaging."
+    )
   failure_message: String!
-  forms: [ReCaptchaForms!]!
+    @doc(
+      description: "The message that appears to the user if validation fails"
+    )
+  forms: [ReCaptchaFormEnum!]!
+    @doc(description: "A list of forms that have reCAPTCHA V3 enabled")
 }
 
 # Google reCAPTCHA config - will return null if v3 invisible is not configured
 # for at least one Storefront form.
-type StoreConfig {
-  recaptcha: ReCaptchaConfiguration
-    @doc(description: "Google reCAPTCHA Configuration")
+type Query {
+  recaptchaV3Config: ReCaptchaConfigurationV3
+    @doc(description: "Google reCAPTCHA V3-Invisible Configuration")
 }


### PR DESCRIPTION
## Problem

Would like to support reCAPTCHA v3 Invisible on PWA storefronts.

## Solution

Add reCAPTCHA configuration to `storeConfig` response in our core extension, magento-commerce/magento2-pwa.

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
