### PR TITLE
PWA-2150: [Spike] Identify discrepancies between GraphQL types Cart and Negotiable Quote

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -237,11 +237,15 @@ type NegotiableQuote {
     # attachments: [AttachmentContent]
     comments: [NegotiableQuoteComment!]
     history: [NegotiableQuoteHistoryEntry!]
+    applied_coupons: [AppliedCoupon] @doc(description:"An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code")
+    email: String
     shipping_addresses: [NegotiableQuoteShippingAddress]!
     billing_address: NegotiableQuoteBillingAddress
     available_payment_methods: [NegotiableQuoteAvailablePaymentMethod]
     selected_payment_method: NegotiableQuoteSelectedPaymentMethod
     prices: NegotiableQuotePrices
+    total_quantity: Float!
+    is_virtual: Boolean!
     buyer: NegotiableQuoteUser!
     created_at: String @doc(description: "Timestamp indicating when the negotiable quote was created.")
     updated_at: String @doc(description: "Timestamp indicating when the negotiable quote was updated.")


### PR DESCRIPTION


## Problem

<!-- In a few words, describe the problem being solved with the proposal. -->
In our GraphQL schemas, the NegotiableQuote type does not contain the same information as the Cart type. We need to identify the missing fields so that we can make the NegotiableQuote schema definition consistent with Cart.

## Solution
update the NegotiableQuote type schema definition to be consistent with the Cart type

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
