### PR TITLE
PWA-1611: Adding the ability to report partial successes

### DIFF
--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -77,6 +77,16 @@ type Mutation {
     # ): AddNegotiableQuoteFilesInput
 }
 
+interface NegotiableQuoteUidNonFatalResultInterface {
+    quote_uid: ID!
+}
+
+type NegotiableQuoteUidOperationSuccess implements NegotiableQuoteUidNonFatalResultInterface {
+}
+
+type NegotiableQuoteInvalidStateError implements ErrorInterface {
+}
+
 type AddNegotiableQuoteItemsOutput {
     quote: NegotiableQuote
     # TODO: We'll probably want to add the same
@@ -157,29 +167,18 @@ input DeleteNegotiableQuotesInput {
     quote_uids: [ID!]! @doc(description: "A List of UIDs obtained from negotiable quote types")
 }
 
-type NegotiableQuoteOperationSuccess {
+union DeleteNegotiableQuoteError = NegotiableQuoteInvalidStateError | NoSuchEntityUidError | InternalError
+
+type DeleteNegotiableQuoteOperationFailure {
     quote_uid: ID!
+    errors: [DeleteNegotiableQuoteError!]!
 }
 
-interface NegotiableQuoteOperationErrorInterface {
-    quote_uid: ID!
-    message: String
-}
-
-type NegotiableQuoteInvalidStateError implements NegotiableQuoteOperationErrorInterface {
-}
-
-type NegotiableQuoteNotFoundError implements NegotiableQuoteOperationErrorInterface {
-}
-
-type NegotiableQuoteUndefinedError implements NegotiableQuoteOperationErrorInterface {
-}
-
-union NegotiableQuoteOperationResult = NegotiableQuoteOperationSuccess | NegotiableQuoteOperationErrorInterface
+union DeleteNegotiableQuoteOperationResult = NegotiableQuoteUidOperationSuccess | DeleteNegotiableQuoteOperationFailure
 
 type DeleteNegotiableQuotesOutput {
-    result_status: MutationResultStatus!
-    operation_results: [NegotiableQuoteOperationResult!]!
+    result_status: BatchMutationStatus!
+    operation_results: [DeleteNegotiableQuoteOperationResult!]!
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
@@ -195,9 +194,18 @@ input CloseNegotiableQuotesInput {
     quote_uids: [ID!]! @doc(description: "A List of IDs from negotiable quote objects")
 }
 
+union CloseNegotiableQuoteError = NegotiableQuoteInvalidStateError | NoSuchEntityUidError | InternalError
+
+type CloseNegotiableQuoteOperationFailure {
+    quote_uid: ID!
+    errors: [CloseNegotiableQuoteError!]!
+}
+
+union CloseNegotiableQuoteOperationResult = NegotiableQuoteUidOperationSuccess | CloseNegotiableQuoteOperationFailure
+
 type CloseNegotiableQuotesOutput {
-    result_status: MutationResultStatus!
-    operation_results: [NegotiableQuoteOperationResult!]!
+    result_status: BatchMutationStatus!
+    operation_results: [CloseNegotiableQuoteOperationResult!]!
     closed_quotes: [NegotiableQuote!] @doc(description: "An array containing the negotiable quotes that were just closed") @deprecated(reason: "Replaced with operation_results")
     #optionally display all negotiable quotes
     negotiable_quotes(
@@ -450,26 +458,7 @@ type RequestNegotiableQuoteOutput {
     quote: NegotiableQuote
 }
 
-type NegotiableQuoteItemOperationSuccess {
-    quote_item_uid: ID!
-}
-
-interface NegotiableQuoteItemOperationErrorInterface {
-    quote_item_uid: ID!
-    message: String
-}
-
-type NegotiableQuoteItemNotFoundError implements NegotiableQuoteItemOperationErrorInterface {
-}
-
-type NegotiableQuoteItemUndefinedError implements NegotiableQuoteItemOperationErrorInterface {
-}
-
-union NegotiableQuoteItemOperationResult = NegotiableQuoteItemOperationSuccess | NegotiableQuoteItemOperationErrorInterface
-
 type RemoveNegotiableQuoteItemsOutput {
-    result_status: MutationResultStatus!
-    operation_results: [NegotiableQuoteItemOperationResult!]!
     quote: NegotiableQuote
 }
 

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -178,7 +178,7 @@ type NegotiableQuoteUndefinedError implements NegotiableQuoteOperationErrorInter
 union NegotiableQuoteOperationResult = NegotiableQuoteOperationSuccess | NegotiableQuoteOperationErrorInterface
 
 type DeleteNegotiableQuotesOutput {
-    result_status: TriStateMutationResultStatus
+    result_status: TriStateMutationResultStatus!
     operation_results: [NegotiableQuoteOperationResult!]!
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
@@ -196,7 +196,7 @@ input CloseNegotiableQuotesInput {
 }
 
 type CloseNegotiableQuotesOutput {
-    result_status: TriStateMutationResultStatus
+    result_status: TriStateMutationResultStatus!
     operation_results: [NegotiableQuoteOperationResult!]!
     closed_quotes: [NegotiableQuote!] @doc(description: "An array containing the negotiable quotes that were just closed") @deprecated(reason: "Replaced with operation_results")
     #optionally display all negotiable quotes
@@ -468,7 +468,7 @@ type NegotiableQuoteItemUndefinedError implements NegotiableQuoteItemOperationEr
 union NegotiableQuoteItemOperationResult = NegotiableQuoteItemOperationSuccess | NegotiableQuoteItemOperationErrorInterface
 
 type RemoveNegotiableQuoteItemsOutput {
-    result_status: TriStateMutationResultStatus
+    result_status: TriStateMutationResultStatus!
     operation_results: [NegotiableQuoteItemOperationResult!]!
     quote: NegotiableQuote
 }

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -157,7 +157,29 @@ input DeleteNegotiableQuotesInput {
     quote_uids: [ID!]! @doc(description: "A List of UIDs obtained from negotiable quote types")
 }
 
+type NegotiableQuoteOperationSuccess {
+    quote_uid: ID!
+}
+
+interface NegotiableQuoteOperationErrorInterface {
+    quote_uid: ID!
+    message: String
+}
+
+type NegotiableQuoteInvalidStateError implements NegotiableQuoteOperationErrorInterface {
+}
+
+type NegotiableQuoteNotFoundError implements NegotiableQuoteOperationErrorInterface {
+}
+
+type NegotiableQuoteUndefinedError implements NegotiableQuoteOperationErrorInterface {
+}
+
+union NegotiableQuoteOperationResult = NegotiableQuoteOperationSuccess | NegotiableQuoteOperationErrorInterface
+
 type DeleteNegotiableQuotesOutput {
+    result_status: TriStateMutationResultStatus
+    operation_results: [NegotiableQuoteOperationResult!]!
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
     # still be visible (and labeled as deleted) for a Seller in the admin
@@ -174,12 +196,9 @@ input CloseNegotiableQuotesInput {
 }
 
 type CloseNegotiableQuotesOutput {
-    closed_quotes(
-        filter: NegotiableQuoteFilterInput,
-        pageSize: Int = 20,
-        currentPage: Int = 1
-        sort: NegotiableQuoteSortInput
-    ): NegotiableQuotesOutput @doc(description: "Quotes that were just closed")
+    result_status: TriStateMutationResultStatus
+    operation_results: [NegotiableQuoteOperationResult!]!
+    closed_quotes: [NegotiableQuote!] @doc(description: "An array containing the negotiable quotes that were just closed") @deprecated(reason: "Replaced with operation_results")
     #optionally display all negotiable quotes
     negotiable_quotes(
         filter: NegotiableQuoteFilterInput,
@@ -431,7 +450,26 @@ type RequestNegotiableQuoteOutput {
     quote: NegotiableQuote
 }
 
+type NegotiableQuoteItemOperationSuccess {
+    quote_item_uid: ID!
+}
+
+interface NegotiableQuoteItemOperationErrorInterface {
+    quote_item_uid: ID!
+    message: String
+}
+
+type NegotiableQuoteItemNotFoundError implements NegotiableQuoteItemOperationErrorInterface {
+}
+
+type NegotiableQuoteUndefinedError implements NegotiableQuoteItemOperationErrorInterface {
+}
+
+union NegotiableQuoteItemOperationResult = NegotiableQuoteItemOperationSuccess | NegotiableQuoteItemOperationErrorInterface
+
 type RemoveNegotiableQuoteItemsOutput {
+    result_status: TriStateMutationResultStatus
+    operation_results: [NegotiableQuoteItemOperationResult!]!
     quote: NegotiableQuote
 }
 

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -178,7 +178,7 @@ type NegotiableQuoteUndefinedError implements NegotiableQuoteOperationErrorInter
 union NegotiableQuoteOperationResult = NegotiableQuoteOperationSuccess | NegotiableQuoteOperationErrorInterface
 
 type DeleteNegotiableQuotesOutput {
-    result_status: TriStateMutationResultStatus!
+    result_status: MutationResultStatus!
     operation_results: [NegotiableQuoteOperationResult!]!
     # Implementation Note: We don't make the deleted quotes accessible
     # because "deleted" means they're hidden from the storefront UI. They will
@@ -196,7 +196,7 @@ input CloseNegotiableQuotesInput {
 }
 
 type CloseNegotiableQuotesOutput {
-    result_status: TriStateMutationResultStatus!
+    result_status: MutationResultStatus!
     operation_results: [NegotiableQuoteOperationResult!]!
     closed_quotes: [NegotiableQuote!] @doc(description: "An array containing the negotiable quotes that were just closed") @deprecated(reason: "Replaced with operation_results")
     #optionally display all negotiable quotes
@@ -468,7 +468,7 @@ type NegotiableQuoteItemUndefinedError implements NegotiableQuoteItemOperationEr
 union NegotiableQuoteItemOperationResult = NegotiableQuoteItemOperationSuccess | NegotiableQuoteItemOperationErrorInterface
 
 type RemoveNegotiableQuoteItemsOutput {
-    result_status: TriStateMutationResultStatus!
+    result_status: MutationResultStatus!
     operation_results: [NegotiableQuoteItemOperationResult!]!
     quote: NegotiableQuote
 }

--- a/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
+++ b/design-documents/graph-ql/coverage/b2b/negotiableQuotes.graphqls
@@ -462,7 +462,7 @@ interface NegotiableQuoteItemOperationErrorInterface {
 type NegotiableQuoteItemNotFoundError implements NegotiableQuoteItemOperationErrorInterface {
 }
 
-type NegotiableQuoteUndefinedError implements NegotiableQuoteItemOperationErrorInterface {
+type NegotiableQuoteItemUndefinedError implements NegotiableQuoteItemOperationErrorInterface {
 }
 
 union NegotiableQuoteItemOperationResult = NegotiableQuoteItemOperationSuccess | NegotiableQuoteItemOperationErrorInterface

--- a/design-documents/graph-ql/directives.graphqls
+++ b/design-documents/graph-ql/directives.graphqls
@@ -37,9 +37,3 @@ directive @typeResolver(class: String="") on UNION
     | OBJECT
 
 directive @cache(cacheIdentity: String="" cacheable: Boolean=true) on QUERY
-
-enum MutationResultStatus {
-    SUCCESS
-    FAILURE
-    PARTIAL_SUCCESS
-}

--- a/design-documents/graph-ql/directives.graphqls
+++ b/design-documents/graph-ql/directives.graphqls
@@ -38,7 +38,7 @@ directive @typeResolver(class: String="") on UNION
 
 directive @cache(cacheIdentity: String="" cacheable: Boolean=true) on QUERY
 
-enum TriStateMutationResultStatus {
+enum MutationResultStatus {
     SUCCESS
     FAILURE
     PARTIAL_SUCCESS

--- a/design-documents/graph-ql/directives.graphqls
+++ b/design-documents/graph-ql/directives.graphqls
@@ -37,3 +37,9 @@ directive @typeResolver(class: String="") on UNION
     | OBJECT
 
 directive @cache(cacheIdentity: String="" cacheable: Boolean=true) on QUERY
+
+enum TriStateMutationResultStatus {
+    SUCCESS
+    FAILURE
+    PARTIAL_SUCCESS
+}

--- a/design-documents/graph-ql/result-status.graphqls
+++ b/design-documents/graph-ql/result-status.graphqls
@@ -1,0 +1,16 @@
+enum BatchMutationStatus {
+    SUCCESS
+    FAILURE
+    MIXED_RESULTS
+}
+
+interface ErrorInterface {
+    message: String!
+}
+
+type NoSuchEntityUidError implements ErrorInterface {
+    uid: ID!
+}
+
+type InternalError implements ErrorInterface {
+}


### PR DESCRIPTION
PWA-1611: Adding the ability to report partial successes on batch operations in Negotiable Quote

## Problem
Some batch mutations in the Negotiable Quote module can have partial successes where some of the items succeed and some fail.  This needs to be reported in a usable way.
<!-- In a few words, describe the problem being solved with the proposal. -->

## Solution
Add a tri-state result status field to these operations with a `SUCCESS`, `FAILURE`, and `PARTIAL_SUCCESS` enum, and include an array result field that reports either a success or a typed failure for each item specified in the batch.

<!-- In a few words, describe the idea of the solution. Provide links to a prototype or proof of concept, if available. -->

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
