### PR TITLE
ConfigurableWishlistItem.child_sku throws an internal error if customer wishlist has un-configured configurable product 

### DIFF
--- a/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
+++ b/design-documents/graph-ql/coverage/customer/Wishlist.graphqls
@@ -1,7 +1,7 @@
 type Mutation {
     createWishlist(input: CreateWishlistInput!): CreateWishlistOutput # Multiple wishlists Commerce functionality
     deleteWishlist(wishlistUid: ID!): DeleteWishlistOutput # Commerce fucntionality - in Opens Source we assume customer always has one wishlist
-    addProductsToWishlist(wishlistId: ID!, wishlistItems: [WishlistItemInput!]!): AddProductsToWishlistOutput 
+    addProductsToWishlist(wishlistId: ID!, wishlistItems: [WishlistItemInput!]!): AddProductsToWishlistOutput
     removeProductsFromWishlist(wishlistId: ID!, wishlistItemsIds: [ID!]!): RemoveProductsFromWishlistOutput
     updateProductsInWishlist(wishlistId: ID!, wishlistItems: [WishlistItemUpdateInput!]!): UpdateProductsInWishlistOutput
     copyProductsBetweenWishlists(sourceWishlistUid: ID!, destinationWishlistUid: ID!, wishlistItems: [WishlistItemCopyInput!]!): CopyProductsBetweenWishlistsOutput  @doc(description: "Copy a product to the wish list")
@@ -14,7 +14,7 @@ type Mutation {
 }
 
 type Customer {
-    wishlist: Wishlist! @deprecated(reason: "Use `Customer.wishlists` or `Customer.wishlist_v2") 
+    wishlist: Wishlist! @deprecated(reason: "Use `Customer.wishlists` or `Customer.wishlist_v2")
     wishlist_v2(id: ID!): Wishlist # This query will be added in the ce
     wishlists: [Wishlist!]! @doc(description: "Customer wishlists are limited to a max of 1 wishlist in Magento Open Source") # This query will be added in the ce
 }
@@ -117,8 +117,9 @@ type VirtualWishlistItem implements WishlistItemInterface @doc(description: "Vir
 }
 
 type ConfigurableWishlistItem implements WishlistItemInterface {
-    child_sku: String! @doc(description: "SKU of the simple product corresponding to a set of selected configurable options.")
-    configurable_options: [SelectedConfigurableOption!]
+    child_sku: String! @deprecated(reason: "Use `ConfigurableWishlistItem.configured_variant.sku` instead.") @doc(description: "The SKU of the simple product corresponding to a set of selected configurable options.")
+    configurable_options: [SelectedConfigurableOption!] @doc(description: "An array of selected configurable options.")
+    configured_variant: ProductInterface @doc(description: "Product details of the selected variant. The value is null if some options are not configured.")
 }
 
 type DownloadableWishlistItem implements WishlistItemInterface @doc(description: "Downloadable Wishlist Item") {


### PR DESCRIPTION
## Problem

[ACP2E-267](https://jira.corp.magento.com/browse/ACP2E-267):  GraphQl - Issues with add Configurable product to Wishlist

```
[2022-01-27T01:13:07.037742+00:00] report.ERROR: Call to a member function getProduct() on null

GraphQL (20:13)
19:           ... on ConfigurableWishlistItem  {
20:             child_sku
                ^
21:             customizable_options {
```

## Solution

Deprecate `ConfigurableWishlistItem.child_sku` and add a new field `ConfigurableWishlistItem.configured_variant` that returns child product details (`ProductInterface `) or NULL if the child product is not configured

## Requested Reviewers

<!-- List reviewers who, in your opinion, can bring the most valuable input. 
See [Component Assignments](https://github.com/magento/architecture/wiki/Component-Assignments) for official assignments, 
but feel free to mention any core or community contributors. 

Mentioning specific reviewers you raise their attention, increase chances of getting valuable input, speed up the review process, and so put the ground to a successful and valuable design document. 
-->
@cpartica
